### PR TITLE
Refactor: Align with updated order status schema

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -40,13 +40,9 @@ export type Database = {
         Row: {
           created_at: string
           customer_name: string | null
-          fulfillment_status:
-            | Database["public"]["Enums"]["fulfillment_status"]
-            | null
           id: number
           order_items: Json | null
           order_status: Database["public"]["Enums"]["order_status"] | null
-          payment_status: Database["public"]["Enums"]["payment_status"] | null
           total_amount: number
           updated_at: string
           user_id: string | null
@@ -54,13 +50,9 @@ export type Database = {
         Insert: {
           created_at?: string
           customer_name?: string | null
-          fulfillment_status?:
-            | Database["public"]["Enums"]["fulfillment_status"]
-            | null
           id?: number
           order_items?: Json | null
           order_status?: Database["public"]["Enums"]["order_status"] | null
-          payment_status?: Database["public"]["Enums"]["payment_status"] | null
           total_amount: number
           updated_at?: string
           user_id?: string | null
@@ -68,13 +60,9 @@ export type Database = {
         Update: {
           created_at?: string
           customer_name?: string | null
-          fulfillment_status?:
-            | Database["public"]["Enums"]["fulfillment_status"]
-            | null
           id?: number
           order_items?: Json | null
           order_status?: Database["public"]["Enums"]["order_status"] | null
-          payment_status?: Database["public"]["Enums"]["payment_status"] | null
           total_amount?: number
           updated_at?: string
           user_id?: string | null
@@ -242,18 +230,13 @@ export type Database = {
       [_ in never]: never
     }
     Enums: {
-      fulfillment_status:
-        | "unfulfilled"
-        | "ready"
-        | "out_for_delivery"
-        | "fulfilled"
-      order_status: "pending" | "confirmed" | "completed" | "cancelled"
-      payment_status:
-        | "unpaid"
-        | "confirming_payment"
-        | "partially_paid"
+      order_status:
+        | "new"
+        | "confirmed"
+        | "completed"
+        | "delivered"
         | "paid"
-        | "refunded"
+        | "cancelled"
     }
     CompositeTypes: {
       [_ in never]: never
@@ -369,19 +352,13 @@ export type CompositeTypes<
 export const Constants = {
   public: {
     Enums: {
-      fulfillment_status: [
-        "unfulfilled",
-        "ready",
-        "out_for_delivery",
-        "fulfilled",
-      ],
-      order_status: ["pending", "confirmed", "completed", "cancelled"],
-      payment_status: [
-        "unpaid",
-        "confirming_payment",
-        "partially_paid",
+      order_status: [
+        "new",
+        "confirmed",
+        "completed",
+        "delivered",
         "paid",
-        "refunded",
+        "cancelled",
       ],
     },
   },

--- a/src/services/orderService.ts
+++ b/src/services/orderService.ts
@@ -2,9 +2,7 @@
 import { supabase } from '@/integrations/supabase/client';
 import { Address, Order, OrderStatus } from '@/types';
 import { 
-  SupabaseOrderStatus, 
-  PaymentStatus as SupabasePaymentStatus, 
-  FulfillmentStatus as SupabaseFulfillmentStatus,
+  SupabaseOrderStatus,
   mapOrderStatusToSupabase,
   mapSupabaseToOrderStatus
 } from '@/types/supabaseTypes';
@@ -46,10 +44,7 @@ export async function fetchUserOrders(userId: string): Promise<Order[] | null> {
         // Determine the correct OrderStatus
         let orderStatus: OrderStatus;
         
-        // Special handling for 'paid' orders
-        if (order.payment_status === 'paid') {
-          orderStatus = OrderStatus.PAID;
-        } else if (order.order_status) {
+        if (order.order_status) {
           // Map Supabase order_status to our application OrderStatus string
           const mappedStatusString = mapSupabaseToOrderStatus(order.order_status as SupabaseOrderStatus);
           
@@ -57,12 +52,11 @@ export async function fetchUserOrders(userId: string): Promise<Order[] | null> {
           switch(mappedStatusString) {
             case 'new': orderStatus = OrderStatus.NEW; break;
             case 'confirmed': orderStatus = OrderStatus.CONFIRMED; break;
-            case 'make': orderStatus = OrderStatus.MAKE; break;
-            case 'ready': orderStatus = OrderStatus.READY; break;
+            case 'completed': orderStatus = OrderStatus.COMPLETED; break;
             case 'delivered': orderStatus = OrderStatus.DELIVERED; break;
             case 'paid': orderStatus = OrderStatus.PAID; break;
             case 'cancelled': orderStatus = OrderStatus.CANCELLED; break;
-            default: orderStatus = OrderStatus.NEW;
+            default: orderStatus = OrderStatus.NEW; // Or handle as an error
           }
         } else {
           // Default fallback
@@ -157,8 +151,6 @@ export async function placeOrderInSupabase(
       order_items: orderItemsJson,
       total_amount: cartTotal,
       order_status: supabaseStatus as SupabaseOrderStatus, // Use the mapped Supabase-compatible value with type assertion
-      payment_status: 'unpaid' as SupabasePaymentStatus,
-      fulfillment_status: 'unfulfilled' as SupabaseFulfillmentStatus,
       table_number: tableNumberInput
     };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -66,8 +66,7 @@ export interface Order {
 export enum OrderStatus {
   NEW = "new",
   CONFIRMED = "confirmed",
-  MAKE = "make",
-  READY = "ready",
+  COMPLETED = "completed",
   DELIVERED = "delivered",
   PAID = "paid",
   CANCELLED = "cancelled",

--- a/src/types/supabaseTypes.ts
+++ b/src/types/supabaseTypes.ts
@@ -10,45 +10,40 @@ export interface Order {
   created_at: string;
   updated_at: string;
   order_status: OrderStatus;
-  payment_status?: PaymentStatus;
-  fulfillment_status?: FulfillmentStatus;
   order_items?: any;
   table_number?: string;
   tip?: number;
 }
 
 // Ensure the OrderStatus type is correctly defined
-export type OrderStatus = "new" | "confirmed" | "make" | "ready" | "delivered" | "paid" | "cancelled";
+export type OrderStatus = "new" | "confirmed" | "completed" | "delivered" | "paid" | "cancelled";
 
 // Map between Supabase enum values and our app's OrderStatus values
-export type SupabaseOrderStatus = "pending" | "confirmed" | "completed" | "cancelled";
+export type SupabaseOrderStatus = "new" | "confirmed" | "completed" | "delivered" | "paid" | "cancelled";
 
 export function mapOrderStatusToSupabase(status: OrderStatus): SupabaseOrderStatus {
   switch (status) {
-    case "new": return "pending";
+    case "new": return "new";
     case "confirmed": return "confirmed";
-    case "make": return "confirmed";
-    case "ready": return "confirmed";
-    case "delivered": return "completed";
-    case "paid": return "completed";
-    case "cancelled": return "cancelled";
-    default: return "pending";
-  }
-}
-
-export function mapSupabaseToOrderStatus(status: SupabaseOrderStatus): OrderStatus {
-  switch (status) {
-    case "pending": return "new";
-    case "confirmed": return "confirmed";
-    case "completed": return "delivered"; // Note: 'completed' from DB typically maps to 'delivered'. If payment_status is 'paid', calling functions usually override this to 'paid'.
+    case "completed": return "completed";
+    case "delivered": return "delivered";
+    case "paid": return "paid";
     case "cancelled": return "cancelled";
     default: return "new";
   }
 }
 
-// Payment and Fulfillment Status types
-export type PaymentStatus = "unpaid" | "confirming_payment" | "partially_paid" | "paid" | "refunded";
-export type FulfillmentStatus = "unfulfilled" | "ready" | "out_for_delivery" | "fulfilled";
+export function mapSupabaseToOrderStatus(status: SupabaseOrderStatus): OrderStatus {
+  switch (status) {
+    case "new": return "new";
+    case "confirmed": return "confirmed";
+    case "completed": return "completed";
+    case "delivered": return "delivered";
+    case "paid": return "paid";
+    case "cancelled": return "cancelled";
+    default: return "new";
+  }
+}
 
 // Profile type
 export interface Profile {

--- a/src/utils/orderDashboardUtils.ts
+++ b/src/utils/orderDashboardUtils.ts
@@ -15,14 +15,16 @@ export const formatDate = (dateString: string | null) => {
 };
 
 // Get the appropriate color for status indicators
-export const getStatusColorDot = (status: string | null) => {
+export const getStatusColorDot = (status: OrderStatus | null) => {
   switch (status) {
     case 'new':
       return "bg-red-500";
     case 'confirmed':
-      return "bg-green-500";
-    case 'delivered':
+      return "bg-yellow-500";
+    case 'completed':
       return "bg-blue-500";
+    case 'delivered':
+      return "bg-green-500";
     case 'paid':
       return "bg-green-700";
     case 'cancelled':
@@ -33,4 +35,4 @@ export const getStatusColorDot = (status: string | null) => {
 };
 
 // Define the order statuses for the dropdown
-export const orderStatusOptions: OrderStatus[] = ['new', 'confirmed', 'delivered', 'paid', 'cancelled'];
+export const orderStatusOptions: OrderStatus[] = ['new', 'confirmed', 'completed', 'delivered', 'paid', 'cancelled'];


### PR DESCRIPTION
This commit updates the codebase to reflect changes in the Supabase 'orders' table schema.

Key changes:
- Removed 'fulfillment_status' and 'payment_status' columns and their associated types and logic throughout the application.
- Updated the 'order_status' enum to support the new values: 'new', 'confirmed', 'completed', 'delivered', 'paid', 'cancelled'.
- The default value for 'order_status' for new orders is 'new'.
- Updated type definitions (Supabase-generated, manual Supabase types, and general application types) to match the new schema.
- Modified the order service to correctly handle the new status mapping and remove dependencies on the deleted fields.
- Updated order dashboard utilities (status options, color coding) to support the new statuses.
- Reviewed and confirmed consistency in components and hooks using order status information.