### PR TITLE
Refactor: Ensure item option prices are integers and display without …

### DIFF
--- a/src/components/ProductOptionsManager.tsx
+++ b/src/components/ProductOptionsManager.tsx
@@ -146,7 +146,7 @@ const ProductOptionsManager: React.FC<ProductOptionsManagerProps> = ({
                         const value = e.target.value.replace(/[^0-9.]/g, '');
                         const decimalCount = (value.match(/\./g) || []).length;
                         if (decimalCount <= 1) {
-                          handleChoiceChange(index, { price_adjustment: parseFloat(value) || 0 });
+                          handleChoiceChange(index, { price_adjustment: Math.round(parseFloat(value) || 0) });
                         }
                       }}
                       placeholder="0"

--- a/src/components/menu-item/ProductOptions.tsx
+++ b/src/components/menu-item/ProductOptions.tsx
@@ -1,5 +1,6 @@
 
 import React from 'react';
+import { formatThaiCurrency } from '@/lib/utils';
 import { Card, CardContent } from '@/components/ui/card';
 import { Label } from '@/components/ui/label';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
@@ -55,7 +56,7 @@ const ProductOptions: React.FC<ProductOptionsProps> = ({
                         className="text-sm cursor-pointer flex justify-between w-full"
                       >
                         <span>{choice.name}</span>
-                        {choice.price_adjustment > 0 && <span>+${choice.price_adjustment.toFixed(2)}</span>}
+                        {choice.price_adjustment > 0 && <span>+{formatThaiCurrency(choice.price_adjustment)}</span>}
                       </label>
                     </div>
                   );
@@ -80,7 +81,7 @@ const ProductOptions: React.FC<ProductOptionsProps> = ({
                       className="text-sm cursor-pointer flex justify-between w-full"
                     >
                       <span>{choice.name}</span>
-                      {choice.price_adjustment > 0 && <span>+${choice.price_adjustment.toFixed(2)}</span>}
+                        {choice.price_adjustment > 0 && <span>+{formatThaiCurrency(choice.price_adjustment)}</span>}
                     </label>
                   </div>
                 ))}


### PR DESCRIPTION
…decimals.

Modifies product option handling to:
1. Display price adjustments for item options as whole numbers using the Thai Baht (฿) symbol and no decimal places on customer-facing pages. This is achieved by utilizing the `formatThaiCurrency` utility function which rounds the amount.
2. Ensure that product option price adjustments are stored as integers. In the `ProductOptionsManager`, input values for price adjustments are rounded to the nearest whole number upon change.

This addresses the issue of decimal points appearing in option prices and ensures consistency in how these prices are managed and displayed.