### PR TITLE
Remove unused tagline on home screen

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -84,7 +84,6 @@ const Index = () => {
             <Card className="border border-gray-200">
               <div className="p-4">
                 <h2 className="text-lg font-semibold">Welcome back, {currentUser.name.split(' ')[0]}!</h2>
-                <p className="text-sm text-gray-600 mb-3">Ready to order your favorites?</p>
                 {adminCustomerContext && (
                   <div className="bg-yellow-100 border-l-4 border-yellow-500 text-yellow-700 p-3 mb-3 rounded">
                     <p className="font-bold">Ordering for: {adminCustomerContext.customerName}</p>


### PR DESCRIPTION
## Summary
- show only "Welcome back" heading on home screen

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_685148eea4348320b2650d7474a4b6e4