### PR TITLE
Remove unused enable quantity UI

### DIFF
--- a/src/components/ProductOptionsManager.tsx
+++ b/src/components/ProductOptionsManager.tsx
@@ -100,14 +100,6 @@ const ProductOptionsManager: React.FC<ProductOptionsManagerProps> = ({
               <label htmlFor={`required-${option.id}`} className="text-sm">Required</label>
             </div>
             
-            <div className="flex items-center space-x-2">
-              <Checkbox 
-                id={`enable-quantity-${option.id}`}
-                checked={option.enable_quantity}
-                onCheckedChange={(checked) => updateOption({ enable_quantity: !!checked })}
-              />
-              <label htmlFor={`enable-quantity-${option.id}`} className="text-sm">Enable quantity</label>
-            </div>
           </div>
           
           <div className="mb-4">

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -121,7 +121,6 @@ export type Database = {
       product_options: {
         Row: {
           created_at: string
-          enable_quantity: boolean
           id: string
           name: string
           product_id: string
@@ -132,7 +131,6 @@ export type Database = {
         }
         Insert: {
           created_at?: string
-          enable_quantity?: boolean
           id?: string
           name: string
           product_id: string
@@ -143,7 +141,6 @@ export type Database = {
         }
         Update: {
           created_at?: string
-          enable_quantity?: boolean
           id?: string
           name?: string
           product_id?: string

--- a/src/pages/useProductMutations.ts
+++ b/src/pages/useProductMutations.ts
@@ -70,7 +70,6 @@ export function useProductMutations({ id, isEditMode, options }: MutationProps) 
               product_id: newProduct.id,
               name: option.name,
               required: option.required,
-              enable_quantity: option.enable_quantity,
               selection_type: option.selection_type,
               sort_order: option.sort_order
             }])
@@ -144,7 +143,6 @@ export function useProductMutations({ id, isEditMode, options }: MutationProps) 
               product_id: id,
               name: option.name,
               required: option.required,
-              enable_quantity: option.enable_quantity,
               selection_type: option.selection_type,
               sort_order: option.sort_order
             }])

--- a/src/pages/useProductOptionsState.ts
+++ b/src/pages/useProductOptionsState.ts
@@ -22,7 +22,6 @@ export function useProductOptionsState(isEditMode: boolean, productOptions: Prod
       product_id: productId || "",
       name: `Option ${options.length + 1}`,
       required: false,
-      enable_quantity: false,
       selection_type: "single",
       choices: [{
         id: `temp-${nanoid()}`,

--- a/src/types/supabaseTypes.ts
+++ b/src/types/supabaseTypes.ts
@@ -225,7 +225,6 @@ export interface ProductOption {
   name: string;
   required: boolean;
   selection_type: "single" | "multiple";
-  enable_quantity: boolean;
   sort_order: number;
   choices: ProductOptionChoice[];
   created_at?: string;


### PR DESCRIPTION
## Summary
- remove the Enable quantity checkbox from option editor
- drop `enable_quantity` fields from option data types and mutations

## Testing
- `npm test -- -t ''` *(no tests found)*
- `npm run lint` *(fails: 47 errors, 12 warnings)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6851ac2dc7ec83209bec8e33137e26eb