### PR TITLE
Fix auto-scroll on menu item detail pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import AppContextProvider from "./context/AppContextProvider";
+import ScrollToTop from "./components/layout/ScrollToTop";
 
 // Pages
 import Index from "./pages/Index";
@@ -31,6 +32,7 @@ import CustomersDashboard from "./pages/CustomersDashboard";
 function App() {
   return (
     <BrowserRouter>
+      <ScrollToTop />
       <TooltipProvider>
         <AppContextProvider>
           <Toaster />

--- a/src/components/layout/ScrollToTop.tsx
+++ b/src/components/layout/ScrollToTop.tsx
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- add `ScrollToTop` component to reset scroll on navigation
- use it inside `App` to start pages at the top

## Testing
- `npm test` *(fails: `vitest` not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685256e1aefc8320b1f56e8285308d9d