### PR TITLE
Fix add-to-cart bar position

### DIFF
--- a/src/components/menu-item/QuantityAddToCart.tsx
+++ b/src/components/menu-item/QuantityAddToCart.tsx
@@ -20,7 +20,7 @@ const QuantityAddToCart: React.FC<QuantityAddToCartProps> = ({
   onAddToCart
 }) => {
   return (
-    <div className="fixed bottom-16 left-0 right-0 p-4 bg-white border-t border-gray-200 shadow-md">
+    <div className="fixed bottom-0 left-0 right-0 p-4 bg-white border-t border-gray-200 shadow-md">
       <div className="max-w-lg mx-auto flex items-center justify-between">
         <div className="flex items-center space-x-4">
           <Button 


### PR DESCRIPTION
## Summary
- ensure item detail page add-to-cart bar is anchored to the bottom of the screen

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68525bd3418c83208cef7791e419a319