### PR TITLE
Add max selections for multi-choice options

### DIFF
--- a/src/components/ProductOptionsManager.tsx
+++ b/src/components/ProductOptionsManager.tsx
@@ -103,11 +103,11 @@ const ProductOptionsManager: React.FC<ProductOptionsManagerProps> = ({
           </div>
           
           <div className="mb-4">
-            <label className="text-sm font-medium block mb-1">Selection</label>
-            <Select 
-              value={option.selection_type} 
-              onValueChange={(value: "single" | "multiple") => updateOption({ selection_type: value })}
-            >
+          <label className="text-sm font-medium block mb-1">Selection</label>
+          <Select
+            value={option.selection_type}
+            onValueChange={(value: "single" | "multiple") => updateOption({ selection_type: value })}
+          >
               <SelectTrigger className="w-[180px]">
                 <SelectValue placeholder="Select type" />
               </SelectTrigger>
@@ -116,6 +116,16 @@ const ProductOptionsManager: React.FC<ProductOptionsManagerProps> = ({
                 <SelectItem value="multiple">Multiple selection</SelectItem>
               </SelectContent>
             </Select>
+            {option.selection_type === 'multiple' && (
+              <Input
+                type="number"
+                min="1"
+                placeholder="Max selections"
+                value={option.max_selections ?? ''}
+                onChange={(e) => updateOption({ max_selections: e.target.value === '' ? null : parseInt(e.target.value, 10) })}
+                className="ml-4 w-32"
+              />
+            )}
           </div>
           
           <div className="space-y-4">

--- a/src/components/menu-item/ProductOptions.tsx
+++ b/src/components/menu-item/ProductOptions.tsx
@@ -32,6 +32,9 @@ const ProductOptions: React.FC<ProductOptionsProps> = ({
             <Label className="text-base font-medium mb-2 block">
               {option.name}
               {option.required && <span className="text-red-500 ml-1">*</span>}
+              {option.selection_type === 'multiple' && option.max_selections && (
+                <span className="text-xs text-gray-500 ml-2">Up to {option.max_selections}</span>
+              )}
             </Label>
             
             {option.selection_type === 'multiple' ? (
@@ -40,16 +43,18 @@ const ProductOptions: React.FC<ProductOptionsProps> = ({
                 {option.choices.map((choice) => {
                   const currentSelection = selectedOptions[option.id];
                   const isChecked = Array.isArray(currentSelection) && currentSelection.includes(choice.name);
+                  const limitReached = option.max_selections && Array.isArray(currentSelection) && currentSelection.length >= option.max_selections;
 
                   return (
                     <div key={choice.name} className="flex items-center space-x-2">
-                      <Checkbox 
+                      <Checkbox
                         id={`${option.id}-${choice.name}`}
                         checked={isChecked}
                         onCheckedChange={(checked) => {
                           onCheckboxChange(option.id, choice.name, checked as boolean);
                         }}
                         className="border-black data-[state=checked]:bg-black data-[state=checked]:text-white"
+                        disabled={!isChecked && !!limitReached}
                       />
                       <label 
                         htmlFor={`${option.id}-${choice.name}`}

--- a/src/hooks/useMenuItemForm.ts
+++ b/src/hooks/useMenuItemForm.ts
@@ -32,10 +32,14 @@ export const useMenuItemForm = (productOptions: ProductOption[] | undefined) => 
   const handleCheckboxChange = (optionId: string, value: string, checked: boolean) => {
     const currentSelection = selectedOptions[optionId];
     const currentValues = Array.isArray(currentSelection) ? currentSelection : [];
-    
+
     let newValues: string[];
     if (checked) {
       newValues = [...currentValues, value];
+      const option = productOptions?.find(o => o.id === optionId);
+      if (option?.max_selections && option.max_selections > 0 && newValues.length > option.max_selections) {
+        return;
+      }
     } else {
       newValues = currentValues.filter(v => v !== value);
     }

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -126,6 +126,7 @@ export type Database = {
           product_id: string
           required: boolean
           selection_type: string
+          max_selections: number | null
           sort_order: number
           updated_at: string
         }
@@ -136,6 +137,7 @@ export type Database = {
           product_id: string
           required?: boolean
           selection_type?: string
+          max_selections?: number | null
           sort_order?: number
           updated_at?: string
         }
@@ -146,6 +148,7 @@ export type Database = {
           product_id?: string
           required?: boolean
           selection_type?: string
+          max_selections?: number | null
           sort_order?: number
           updated_at?: string
         }

--- a/src/pages/useProductMutations.ts
+++ b/src/pages/useProductMutations.ts
@@ -71,6 +71,7 @@ export function useProductMutations({ id, isEditMode, options }: MutationProps) 
               name: option.name,
               required: option.required,
               selection_type: option.selection_type,
+              max_selections: option.max_selections,
               sort_order: option.sort_order
             }])
             .select()
@@ -144,6 +145,7 @@ export function useProductMutations({ id, isEditMode, options }: MutationProps) 
               name: option.name,
               required: option.required,
               selection_type: option.selection_type,
+              max_selections: option.max_selections,
               sort_order: option.sort_order
             }])
             .select()

--- a/src/pages/useProductOptionsState.ts
+++ b/src/pages/useProductOptionsState.ts
@@ -23,6 +23,7 @@ export function useProductOptionsState(isEditMode: boolean, productOptions: Prod
       name: `Option ${options.length + 1}`,
       required: false,
       selection_type: "single",
+      max_selections: null,
       choices: [{
         id: `temp-${nanoid()}`,
         option_id: '',

--- a/src/types/supabaseTypes.ts
+++ b/src/types/supabaseTypes.ts
@@ -225,6 +225,7 @@ export interface ProductOption {
   name: string;
   required: boolean;
   selection_type: "single" | "multiple";
+  max_selections?: number | null;
   sort_order: number;
   choices: ProductOptionChoice[];
   created_at?: string;

--- a/supabase/migrations/20250616160000-add-max-selections-to-product-options.sql
+++ b/supabase/migrations/20250616160000-add-max-selections-to-product-options.sql
@@ -1,0 +1,3 @@
+-- Add max_selections column to product_options table
+ALTER TABLE public.product_options
+ADD COLUMN max_selections integer;


### PR DESCRIPTION
## Summary
- allow setting a maximum number of selections per product option
- show the limit field for admins and enforce it on the menu page
- update Supabase types and create migration

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68527c628bbc8320b3562289a3f63135