### PR TITLE
Remove internal scroll from order lists

### DIFF
--- a/src/components/customer/CustomerOrderCard.tsx
+++ b/src/components/customer/CustomerOrderCard.tsx
@@ -57,7 +57,7 @@ const CustomerOrderCard = ({ order }: CustomerOrderCardProps) => {
             </Badge>
           )}
         </div>
-        <div className="mt-3 mb-3 max-h-24 overflow-y-auto">
+        <div className="mt-3 mb-3">
           {Array.isArray(order.order_items) && order.order_items.map((item: any, idx: number) => {
             const name = item.name || (item.menuItem && item.menuItem.name) || "Item";
             const price = (typeof item.price === "number"

--- a/src/pages/OrderHistory.tsx
+++ b/src/pages/OrderHistory.tsx
@@ -103,7 +103,7 @@ const OrderHistory = () => {
                        </Badge>
                     )}
                   </div>
-                  <div className="mt-3 mb-3 max-h-24 overflow-y-auto">
+                  <div className="mt-3 mb-3">
                     {Array.isArray(order.order_items) && order.order_items.map((item: any, idx: number) => {
                       const hasMenuItem = item.menuItem && typeof item.menuItem === 'object';
                       const name = hasMenuItem ? item.menuItem.name : (item.name || "Item");


### PR DESCRIPTION
## Summary
- adjust order cards to avoid inner scroll

## Testing
- `npm run lint` *(fails: cannot find module `@eslint/js`)*
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852dd9c3cfc83208c23cdae5f3ee3c1