### PR TITLE
Align product dashboard buttons with categories

### DIFF
--- a/src/components/admin/DraggableProductGrid.tsx
+++ b/src/components/admin/DraggableProductGrid.tsx
@@ -3,17 +3,6 @@ import React from 'react';
 import { DndContext, DragEndEvent, closestCenter } from '@dnd-kit/core';
 import { SortableContext, verticalListSortingStrategy, arrayMove } from '@dnd-kit/sortable';
 import { Trash, GripVertical, Plus, Edit } from 'lucide-react';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from '@/components/ui/alert-dialog';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { Button } from '@/components/ui/button';
@@ -108,8 +97,8 @@ const DraggableProductItem: React.FC<DraggableProductItemProps> = ({ product, na
           </span>
           <div className="flex gap-2">
             <Button
-              variant="outline"
-              size="icon"
+              variant="ghost"
+              size="sm"
               onClick={(e) => {
                 e.stopPropagation();
                 navigate(`/products/edit/${product.id}`);
@@ -118,35 +107,19 @@ const DraggableProductItem: React.FC<DraggableProductItemProps> = ({ product, na
               <Edit className="h-4 w-4" />
             </Button>
             {isAdmin && (
-              <AlertDialog>
-                <AlertDialogTrigger asChild>
-                  <Button
-                    variant="destructive"
-                    size="icon"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      // AlertDialog will open via its trigger
-                    }}
-                  >
-                    <Trash className="h-4 w-4" />
-                  </Button>
-                </AlertDialogTrigger>
-              <AlertDialogContent onClick={(e) => e.stopPropagation()}>
-                <AlertDialogHeader>
-                  <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
-                  <AlertDialogDescription>
-                    This action cannot be undone. This will permanently delete the product.
-                  </AlertDialogDescription>
-                </AlertDialogHeader>
-                <AlertDialogFooter>
-                  <AlertDialogCancel>Cancel</AlertDialogCancel>
-                  <AlertDialogAction onClick={() => onDelete(product.id)}>
-                    Delete
-                  </AlertDialogAction>
-                </AlertDialogFooter>
-              </AlertDialogContent>
-            </AlertDialog>
-          )}
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  if (confirm('Are you sure you want to delete this product?')) {
+                    onDelete(product.id);
+                  }
+                }}
+              >
+                <Trash className="h-4 w-4" />
+              </Button>
+            )}
           </div>
         </CardFooter>
       </div>


### PR DESCRIPTION
## Summary
- style product edit/delete buttons in DraggableProductGrid like those in CategoriesManager
- use simple `confirm()` prompt for deleting products

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854fe5a46a88320a7094de5c091d2d1