### PR TITLE
Add analytics page for orders over time

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import ResetPassword from "./pages/ResetPassword";   // Added
 import Profile from "./pages/Profile";
 import OrderHistory from "./pages/OrderHistory";
 import OrdersDashboard from "./pages/OrdersDashboard";
+import OrdersOverTime from "./pages/OrdersOverTime";
 import Admin from "./pages/Admin";
 import NotFound from "./pages/NotFound";
 import ProductsDashboard from "./pages/ProductsDashboard";
@@ -58,6 +59,7 @@ function App() {
               <Route path="/products/new" element={<ProductForm />} />
               <Route path="/products/edit/:productId" element={<ProductForm />} />
               <Route path="/orders-dashboard" element={<OrdersDashboard />} />
+              <Route path="/orders-over-time" element={<OrdersOverTime />} />
               <Route path="/admin/orders/:orderId" element={<AdminOrderDetail />} />
               <Route path="/categories-manager" element={<CategoriesManager />} />
               <Route path="/admin/customer-orders/:customerId" element={<CustomerOrderHistory />} />

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 import Layout from '@/components/layout/Layout';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Users, Package, LayoutGrid, ShoppingCart } from 'lucide-react';
+import { Users, Package, LayoutGrid, ShoppingCart, BarChart3 } from 'lucide-react';
 
 const Admin = () => {
   return (
@@ -64,6 +64,20 @@ const Admin = () => {
               </CardHeader>
               <CardContent>
                 <p className="text-sm text-muted-foreground">View and manage customer accounts</p>
+              </CardContent>
+            </Card>
+          </Link>
+
+          <Link to="/orders-over-time">
+            <Card className="hover:shadow-md transition-shadow">
+              <CardHeader className="pb-2">
+                <CardTitle className="flex items-center gap-2">
+                  <BarChart3 className="h-5 w-5" />
+                  Analytics
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-sm text-muted-foreground">View sales over time</p>
               </CardContent>
             </Card>
           </Link>

--- a/src/pages/OrdersOverTime.tsx
+++ b/src/pages/OrdersOverTime.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import Layout from '@/components/layout/Layout';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  ChartContainer,
+  ChartLegendContent,
+  ChartTooltipContent,
+} from '@/components/ui/chart';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts';
+import { useOrdersByDate } from '@/hooks/useOrdersByDate';
+
+const OrdersOverTime = () => {
+  const { data, isLoading, error } = useOrdersByDate();
+
+  const chartData = Object.entries(data).map(([date, values]) => ({
+    date,
+    hotel_guest: values.hotel_guest,
+    outside_guest: values.outside_guest,
+  }));
+
+  return (
+    <Layout title="Orders Over Time" showBackButton>
+      <div className="p-4 md:p-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Orders Over Time</CardTitle>
+          </CardHeader>
+          <CardContent className="p-4">
+            {isLoading ? (
+              <div className="p-6 text-center text-muted-foreground">Loading analytics...</div>
+            ) : error ? (
+              <div className="p-6 text-center text-destructive">Failed to load data</div>
+            ) : (
+              <ChartContainer
+                config={{
+                  hotel_guest: { label: 'Hotel Guest', color: 'hsl(var(--primary))' },
+                  outside_guest: { label: 'Outside Guest', color: 'hsl(var(--secondary))' },
+                }}
+              >
+                <ResponsiveContainer width="100%" height={300}>
+                  <BarChart data={chartData}>
+                    <CartesianGrid strokeDasharray="3 3" />
+                    <XAxis dataKey="date" />
+                    <YAxis />
+                    <Tooltip content={<ChartTooltipContent />} />
+                    <Legend content={<ChartLegendContent />} />
+                    <Bar dataKey="hotel_guest" stackId="orders" fill="var(--color-hotel_guest)" />
+                    <Bar dataKey="outside_guest" stackId="orders" fill="var(--color-outside_guest)" />
+                  </BarChart>
+                </ResponsiveContainer>
+              </ChartContainer>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </Layout>
+  );
+};
+
+export default OrdersOverTime;


### PR DESCRIPTION
## Summary
- add new `OrdersOverTime` page with stacked bar chart
- link the page from the admin dashboard
- register the route in `App.tsx`

## Testing
- `npm test` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6855968d076c8320befc7fb5d890ddc0