### PR TITLE
Add analytics chart page

### DIFF
--- a/src/hooks/useOrdersByDate.ts
+++ b/src/hooks/useOrdersByDate.ts
@@ -1,49 +1,31 @@
-import { useEffect, useState } from 'react';
-import { supabase } from '@/integrations/supabase/client';
+import { useEffect, useState } from 'react'
+import { supabase } from '@/integrations/supabase/client'
 
-interface OrdersByDateRow {
-  order_date: string;
-  guest_type: 'hotel_guest' | 'outside_guest';
-  total_amount: number;
+type OrdersByDate = {
+  order_date: string
+  guest_amount: number
+  non_guest_amount: number
 }
 
-type OrdersGrouped = {
-  [date: string]: {
-    hotel_guest: number;
-    outside_guest: number;
-  };
-};
-
-export function useOrdersByDate() {
-  const [data, setData] = useState<OrdersGrouped>({});
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<Error | null>(null);
+export const useOrdersByDate = (startDate: string, endDate: string) => {
+  const [data, setData] = useState<OrdersByDate[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
-    async function fetchData() {
-      setIsLoading(true);
-      const { data: rows, error } = await supabase.rpc('orders_by_day_and_guest_type');
-
-      if (error) {
-        setError(error);
-        setIsLoading(false);
-        return;
-      }
-
-      const grouped: OrdersGrouped = {};
-      for (const row of (rows as OrdersByDateRow[]) || []) {
-        if (!grouped[row.order_date]) {
-          grouped[row.order_date] = { hotel_guest: 0, outside_guest: 0 };
-        }
-        grouped[row.order_date][row.guest_type] = row.total_amount;
-      }
-
-      setData(grouped);
-      setIsLoading(false);
+    const fetchData = async () => {
+      setIsLoading(true)
+      const { data, error } = await supabase.rpc('orders_by_day_and_guest_type', {
+        start_date: startDate,
+        end_date: endDate
+      })
+      if (error) setError(error.message)
+      else setData(data as OrdersByDate[])
+      setIsLoading(false)
     }
 
-    fetchData();
-  }, []);
+    fetchData()
+  }, [startDate, endDate])
 
-  return { data, isLoading, error } as const;
+  return { data, isLoading, error }
 }

--- a/src/pages/OrdersOverTime.tsx
+++ b/src/pages/OrdersOverTime.tsx
@@ -17,14 +17,17 @@ import {
   ResponsiveContainer,
 } from 'recharts';
 import { useOrdersByDate } from '@/hooks/useOrdersByDate';
+import { format, subDays } from 'date-fns';
 
 const OrdersOverTime = () => {
-  const { data, isLoading, error } = useOrdersByDate();
+  const endDate = format(new Date(), 'yyyy-MM-dd');
+  const startDate = format(subDays(new Date(), 30), 'yyyy-MM-dd');
+  const { data, isLoading, error } = useOrdersByDate(startDate, endDate);
 
-  const chartData = Object.entries(data).map(([date, values]) => ({
-    date,
-    hotel_guest: values.hotel_guest,
-    outside_guest: values.outside_guest,
+  const chartData = data.map((row) => ({
+    date: row.order_date,
+    hotel_guest: row.guest_amount,
+    outside_guest: row.non_guest_amount,
   }));
 
   return (

--- a/src/pages/admin/analytics/OrdersOverTimeChart.tsx
+++ b/src/pages/admin/analytics/OrdersOverTimeChart.tsx
@@ -1,0 +1,72 @@
+import React from 'react'
+import Layout from '@/components/layout/Layout'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  ChartContainer,
+  ChartLegendContent,
+  ChartTooltipContent,
+} from '@/components/ui/chart'
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts'
+import { useOrdersByDate } from '@/hooks/useOrdersByDate'
+import { format, subDays } from 'date-fns'
+
+const OrdersOverTimeChart = () => {
+  const endDate = format(new Date(), 'yyyy-MM-dd')
+  const startDate = format(subDays(new Date(), 30), 'yyyy-MM-dd')
+  const { data, isLoading, error } = useOrdersByDate(startDate, endDate)
+
+  const chartData = data.map((row) => ({
+    date: row.order_date,
+    hotel_guest: row.guest_amount,
+    non_guest: row.non_guest_amount,
+  }))
+
+  return (
+    <Layout title="Orders Over Time" showBackButton>
+      <div className="p-4 md:p-6">
+        <Card className="bg-white text-black dark:bg-black dark:text-white border border-black">
+          <CardHeader>
+            <CardTitle>Orders Over Time</CardTitle>
+          </CardHeader>
+          <CardContent className="p-4">
+            {isLoading ? (
+              <div className="p-6 text-center text-gray-500">Loading analytics...</div>
+            ) : error ? (
+              <div className="p-6 text-center text-red-500">Failed to load data</div>
+            ) : (
+              <ChartContainer
+                config={{
+                  hotel_guest: { label: 'Hotel Guest', color: '#000' },
+                  non_guest: { label: 'Non Guest', color: '#888' },
+                }}
+              >
+                <ResponsiveContainer width="100%" height={300}>
+                  <BarChart data={chartData}>
+                    <CartesianGrid strokeDasharray="3 3" stroke="#e5e5e5" />
+                    <XAxis dataKey="date" stroke="#000" />
+                    <YAxis stroke="#000" />
+                    <Tooltip content={<ChartTooltipContent />} />
+                    <Legend content={<ChartLegendContent />} />
+                    <Bar dataKey="hotel_guest" stackId="orders" fill="var(--color-hotel_guest)" />
+                    <Bar dataKey="non_guest" stackId="orders" fill="var(--color-non_guest)" />
+                  </BarChart>
+                </ResponsiveContainer>
+              </ChartContainer>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </Layout>
+  )
+}
+
+export default OrdersOverTimeChart


### PR DESCRIPTION
## Summary
- create an updated `useOrdersByDate` hook that accepts a date range
- update `OrdersOverTime` page to use the new hook signature
- add minimalist black & white admin analytics page `OrdersOverTimeChart`

## Testing
- `npm test` *(fails: no test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68559b17a7b0832087b86dbe6427dd9d