### PR TITLE
Add orders over time analytics page

### DIFF
--- a/src/pages/admin/analytics/OrdersOverTimeChart.tsx
+++ b/src/pages/admin/analytics/OrdersOverTimeChart.tsx
@@ -1,0 +1,12 @@
+import Layout from '@/components/layout/Layout'
+import OrdersOverTimeChart from '@/components/analytics/OrdersOverTimeChart'
+
+export default function OrdersOverTimePage() {
+  return (
+    <Layout title="Orders Over Time">
+      <div className="p-4">
+        <OrdersOverTimeChart />
+      </div>
+    </Layout>
+  )
+}


### PR DESCRIPTION
## Summary
- create `OrdersOverTimeChart` page under `admin/analytics`

## Testing
- `npm test` *(fails: no test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68559c6c56908320b323cb5b9157e35a