### PR TITLE
Add admin analytics link

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import Profile from "./pages/Profile";
 import OrderHistory from "./pages/OrderHistory";
 import OrdersDashboard from "./pages/OrdersDashboard";
 import OrdersOverTime from "./pages/OrdersOverTime";
+import OrdersOverTimeChart from "./pages/admin/analytics/OrdersOverTimeChart";
 import Admin from "./pages/Admin";
 import NotFound from "./pages/NotFound";
 import ProductsDashboard from "./pages/ProductsDashboard";
@@ -60,6 +61,7 @@ function App() {
               <Route path="/products/edit/:productId" element={<ProductForm />} />
               <Route path="/orders-dashboard" element={<OrdersDashboard />} />
               <Route path="/orders-over-time" element={<OrdersOverTime />} />
+              <Route path="/admin/analytics/orders-over-time" element={<OrdersOverTimeChart />} />
               <Route path="/admin/orders/:orderId" element={<AdminOrderDetail />} />
               <Route path="/categories-manager" element={<CategoriesManager />} />
               <Route path="/admin/customer-orders/:customerId" element={<CustomerOrderHistory />} />

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 import Layout from '@/components/layout/Layout';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Users, Package, LayoutGrid, ShoppingCart, BarChart3 } from 'lucide-react';
+import { Users, Package, LayoutGrid, ShoppingCart, BarChart } from 'lucide-react';
 
 const Admin = () => {
   return (
@@ -68,12 +68,12 @@ const Admin = () => {
             </Card>
           </Link>
 
-          <Link to="/orders-over-time">
+          <Link to="/admin/analytics/orders-over-time">
             <Card className="hover:shadow-md transition-shadow">
               <CardHeader className="pb-2">
                 <CardTitle className="flex items-center gap-2">
-                  <BarChart3 className="h-5 w-5" />
-                  Analytics
+                  <BarChart className="h-5 w-5" />
+                  Orders Over Time
                 </CardTitle>
               </CardHeader>
               <CardContent>


### PR DESCRIPTION
## Summary
- add admin analytics page route
- link to Orders Over Time in admin dashboard

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68559d2ce4548320a286c8538797b792