### PR TITLE
Add analytics link to admin dashboard

### DIFF
--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -4,7 +4,13 @@ import { Link } from 'react-router-dom';
 import Layout from '@/components/layout/Layout';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Users, Package, LayoutGrid, ShoppingCart, BarChart } from 'lucide-react';
+import {
+  Users,
+  Package,
+  LayoutGrid,
+  ShoppingCart,
+  BarChart,
+} from 'lucide-react';
 
 const Admin = () => {
   return (
@@ -64,6 +70,20 @@ const Admin = () => {
               </CardHeader>
               <CardContent>
                 <p className="text-sm text-muted-foreground">View and manage customer accounts</p>
+              </CardContent>
+            </Card>
+          </Link>
+
+          <Link to="/admin/analytics/orders-over-time">
+            <Card className="hover:shadow-md transition-shadow">
+              <CardHeader className="pb-2">
+                <CardTitle className="flex items-center gap-2">
+                  <BarChart className="h-5 w-5" />
+                  Analytics
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-sm text-muted-foreground">View sales analytics</p>
               </CardContent>
             </Card>
           </Link>


### PR DESCRIPTION
## Summary
- expose Analytics link under Admin dashboard

## Testing
- `npm run lint` *(fails: cannot find module '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68559f7077e08320af32add485b60e37