### PR TITLE
Add order count toggle for analytics chart

### DIFF
--- a/src/hooks/useOrdersByDate.ts
+++ b/src/hooks/useOrdersByDate.ts
@@ -5,6 +5,8 @@ type OrdersByDate = {
   order_date: string
   guest_amount: number
   non_guest_amount: number
+  guest_count: number
+  non_guest_count: number
 }
 
 export const useOrdersByDate = (startDate: string, endDate: string) => {

--- a/src/pages/admin/analytics/OrdersOverTimeChart.tsx
+++ b/src/pages/admin/analytics/OrdersOverTimeChart.tsx
@@ -18,24 +18,56 @@ import {
 } from 'recharts'
 import { useOrdersByDate } from '@/hooks/useOrdersByDate'
 import { format, subDays } from 'date-fns'
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 
 const OrdersOverTimeChart = () => {
   const endDate = format(new Date(), 'yyyy-MM-dd')
   const startDate = format(subDays(new Date(), 30), 'yyyy-MM-dd')
   const { data, isLoading, error } = useOrdersByDate(startDate, endDate)
 
+  const [metric, setMetric] = React.useState<'revenue' | 'orders'>(() => {
+    if (typeof window === 'undefined') return 'revenue'
+    return (localStorage.getItem('ordersOverTimeMetric') as 'revenue' | 'orders') || 'revenue'
+  })
+
+  React.useEffect(() => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('ordersOverTimeMetric', metric)
+    }
+  }, [metric])
+
   const chartData = data.map((row) => ({
     date: row.order_date,
-    hotel_guest: row.guest_amount,
-    non_guest: row.non_guest_amount,
+    hotel_guest:
+      metric === 'revenue' ? row.guest_amount : row.guest_count,
+    non_guest:
+      metric === 'revenue' ? row.non_guest_amount : row.non_guest_count,
   }))
+
+  const total = data.reduce(
+    (sum, row) =>
+      sum +
+      (metric === 'revenue'
+        ? row.guest_amount + row.non_guest_amount
+        : row.guest_count + row.non_guest_count),
+    0
+  )
 
   return (
     <Layout title="Orders Over Time" showBackButton>
       <div className="p-4 md:p-6">
         <Card className="bg-white text-black dark:bg-black dark:text-white border border-black">
-          <CardHeader>
+          <CardHeader className="flex flex-col gap-2">
             <CardTitle>Orders Over Time</CardTitle>
+            <ToggleGroup
+              type="single"
+              value={metric}
+              onValueChange={(v) => v && setMetric(v as 'revenue' | 'orders')}
+              className="self-start"
+            >
+              <ToggleGroupItem value="revenue">Revenue</ToggleGroupItem>
+              <ToggleGroupItem value="orders">Orders</ToggleGroupItem>
+            </ToggleGroup>
           </CardHeader>
           <CardContent className="p-4">
             {isLoading ? (
@@ -51,9 +83,9 @@ const OrdersOverTimeChart = () => {
               >
                 <ResponsiveContainer width="100%" height={300}>
                   <BarChart data={chartData}>
-                    <CartesianGrid strokeDasharray="3 3" stroke="#e5e5e5" />
-                    <XAxis dataKey="date" stroke="#000" />
-                    <YAxis stroke="#000" />
+                    <CartesianGrid strokeDasharray="3 3" stroke="#e5e5e5" vertical={false} />
+                    <XAxis dataKey="date" stroke="#000" axisLine={false} tickLine={false} />
+                    <YAxis stroke="#000" axisLine={false} tickLine={false} />
                     <Tooltip content={<ChartTooltipContent />} />
                     <Legend content={<ChartLegendContent />} />
                     <Bar dataKey="hotel_guest" stackId="orders" fill="var(--color-hotel_guest)" />
@@ -61,6 +93,10 @@ const OrdersOverTimeChart = () => {
                   </BarChart>
                 </ResponsiveContainer>
               </ChartContainer>
+              <div className="mt-2 font-mono text-sm">
+                Total {metric === 'revenue' ? 'Revenue' : 'Orders'}:{' '}
+                {total.toLocaleString()}
+              </div>
             )}
           </CardContent>
         </Card>

--- a/supabase/migrations/20250620130000-update-orders-by-day-and-guest-type-function.sql
+++ b/supabase/migrations/20250620130000-update-orders-by-day-and-guest-type-function.sql
@@ -1,0 +1,32 @@
+-- Update orders_by_day_and_guest_type function to include order counts
+DROP FUNCTION IF EXISTS public.orders_by_day_and_guest_type();
+
+CREATE FUNCTION public.orders_by_day_and_guest_type(
+  start_date date,
+  end_date date
+)
+RETURNS TABLE(
+  order_date date,
+  guest_amount numeric,
+  non_guest_amount numeric,
+  guest_count integer,
+  non_guest_count integer
+)
+LANGUAGE sql
+AS $$
+  SELECT
+    date(o.created_at) AS order_date,
+    SUM(CASE WHEN p.customer_type = 'hotel_guest' THEN o.total_amount ELSE 0 END) AS guest_amount,
+    SUM(CASE WHEN p.customer_type = 'hotel_guest' THEN 0 ELSE o.total_amount END) AS non_guest_amount,
+    COUNT(CASE WHEN p.customer_type = 'hotel_guest' THEN o.id END) AS guest_count,
+    COUNT(CASE WHEN p.customer_type = 'hotel_guest' THEN NULL ELSE o.id END) AS non_guest_count
+  FROM public.orders o
+  LEFT JOIN public.profiles p ON o.user_id = p.id
+  WHERE o.order_status IN ('paid', 'completed')
+    AND date(o.created_at) BETWEEN start_date AND end_date
+  GROUP BY order_date
+  ORDER BY order_date DESC
+$$;
+
+-- Grant permission for authenticated users
+GRANT EXECUTE ON FUNCTION public.orders_by_day_and_guest_type(date, date) TO authenticated;


### PR DESCRIPTION
## Summary
- add new migration to include order counts in `orders_by_day_and_guest_type`
- expand `useOrdersByDate` hook type with count fields
- allow toggling between revenue and order count in `OrdersOverTimeChart`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6855a1fdb108832082fae68c4a9b6b4a