### PR TITLE
Enhance orders over time chart

### DIFF
--- a/src/hooks/useOrdersByDate.ts
+++ b/src/hooks/useOrdersByDate.ts
@@ -3,11 +3,17 @@ import { supabase } from '@/integrations/supabase/client'
 
 type OrdersByDate = {
   order_date: string
-  guest_amount: number
-  non_guest_amount: number
+  hotel_guest_orders: number
+  hotel_guest_revenue: number
+  outside_guest_orders: number
+  outside_guest_revenue: number
 }
 
-export const useOrdersByDate = (startDate: string, endDate: string) => {
+export const useOrdersByDate = (
+  startDate: string,
+  endDate: string,
+  metric: 'revenue' | 'count'
+) => {
   const [data, setData] = useState<OrdersByDate[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -17,7 +23,8 @@ export const useOrdersByDate = (startDate: string, endDate: string) => {
       setIsLoading(true)
       const { data, error } = await supabase.rpc('orders_by_day_and_guest_type', {
         start_date: startDate,
-        end_date: endDate
+        end_date: endDate,
+        metric,
       })
       if (error) setError(error.message)
       else setData(data as OrdersByDate[])
@@ -25,7 +32,7 @@ export const useOrdersByDate = (startDate: string, endDate: string) => {
     }
 
     fetchData()
-  }, [startDate, endDate])
+  }, [startDate, endDate, metric])
 
   return { data, isLoading, error }
 }

--- a/src/pages/OrdersOverTime.tsx
+++ b/src/pages/OrdersOverTime.tsx
@@ -22,12 +22,12 @@ import { format, subDays } from 'date-fns';
 const OrdersOverTime = () => {
   const endDate = format(new Date(), 'yyyy-MM-dd');
   const startDate = format(subDays(new Date(), 30), 'yyyy-MM-dd');
-  const { data, isLoading, error } = useOrdersByDate(startDate, endDate);
+  const { data, isLoading, error } = useOrdersByDate(startDate, endDate, 'count');
 
   const chartData = data.map((row) => ({
     date: row.order_date,
-    hotel_guest: row.guest_amount,
-    outside_guest: row.non_guest_amount,
+    hotel_guest: row.hotel_guest_orders,
+    outside_guest: row.outside_guest_orders,
   }));
 
   return (

--- a/src/pages/admin/analytics/OrdersOverTimeChart.tsx
+++ b/src/pages/admin/analytics/OrdersOverTimeChart.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import Layout from '@/components/layout/Layout'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import {
@@ -18,17 +18,33 @@ import {
 } from 'recharts'
 import { useOrdersByDate } from '@/hooks/useOrdersByDate'
 import { format, subDays } from 'date-fns'
+import { DateRange } from 'react-day-picker'
+import { CalendarIcon } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { Calendar } from '@/components/ui/calendar'
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
+import { formatThaiCurrency } from '@/lib/utils'
 
 const OrdersOverTimeChart = () => {
-  const endDate = format(new Date(), 'yyyy-MM-dd')
-  const startDate = format(subDays(new Date(), 30), 'yyyy-MM-dd')
-  const { data, isLoading, error } = useOrdersByDate(startDate, endDate)
+  const [metric, setMetric] = useState<'revenue' | 'count'>('revenue')
+  const [range, setRange] = useState<DateRange>({
+    from: subDays(new Date(), 30),
+    to: new Date(),
+  })
+
+  const endDate = range.to ? format(range.to, 'yyyy-MM-dd') : format(new Date(), 'yyyy-MM-dd')
+  const startDate = range.from ? format(range.from, 'yyyy-MM-dd') : endDate
+
+  const { data, isLoading, error } = useOrdersByDate(startDate, endDate, metric)
 
   const chartData = data.map((row) => ({
     date: row.order_date,
-    hotel_guest: row.guest_amount,
-    non_guest: row.non_guest_amount,
+    hotel_guest: metric === 'revenue' ? row.hotel_guest_revenue : row.hotel_guest_orders,
+    non_guest: metric === 'revenue' ? row.outside_guest_revenue : row.outside_guest_orders,
   }))
+
+  const total = chartData.reduce((sum, row) => sum + row.hotel_guest + row.non_guest, 0)
 
   return (
     <Layout title="Orders Over Time" showBackButton>
@@ -36,6 +52,48 @@ const OrdersOverTimeChart = () => {
         <Card className="bg-white text-black dark:bg-black dark:text-white border border-black">
           <CardHeader>
             <CardTitle>Orders Over Time</CardTitle>
+            <div className="flex flex-col gap-2 pt-4 md:flex-row md:items-center md:justify-between">
+              <div className="flex items-center gap-2">
+                <Popover>
+                  <PopoverTrigger asChild>
+                    <Button variant="outline" className="text-sm font-normal w-[260px] justify-start">
+                      <CalendarIcon className="mr-2 h-4 w-4" />
+                      {range.from ? (
+                        range.to ? (
+                          <>{format(range.from, 'LLL dd, y')} - {format(range.to, 'LLL dd, y')}</>
+                        ) : (
+                          format(range.from, 'LLL dd, y')
+                        )
+                      ) : (
+                        <span>Pick a date</span>
+                      )}
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent className="w-auto p-0" align="start">
+                    <Calendar
+                      initialFocus
+                      mode="range"
+                      defaultMonth={range.from}
+                      selected={range}
+                      onSelect={setRange}
+                      numberOfMonths={2}
+                    />
+                  </PopoverContent>
+                </Popover>
+                <ToggleGroup
+                  type="single"
+                  value={metric}
+                  onValueChange={(val) => val && setMetric(val as 'revenue' | 'count')}
+                  className="ml-2"
+                >
+                  <ToggleGroupItem value="revenue">THB</ToggleGroupItem>
+                  <ToggleGroupItem value="count">Orders</ToggleGroupItem>
+                </ToggleGroup>
+              </div>
+              <div className="text-lg font-bold md:ml-auto">
+                {metric === 'revenue' ? formatThaiCurrency(total) : total.toLocaleString()}
+              </div>
+            </div>
           </CardHeader>
           <CardContent className="p-4">
             {isLoading ? (
@@ -45,19 +103,19 @@ const OrdersOverTimeChart = () => {
             ) : (
               <ChartContainer
                 config={{
-                  hotel_guest: { label: 'Hotel Guest', color: '#000' },
-                  non_guest: { label: 'Non Guest', color: '#888' },
+                  hotel_guest: { label: 'Hotel Guest', color: '#ffffff' },
+                  non_guest: { label: 'Non Guest', color: '#000000' },
                 }}
               >
                 <ResponsiveContainer width="100%" height={300}>
-                  <BarChart data={chartData}>
-                    <CartesianGrid strokeDasharray="3 3" stroke="#e5e5e5" />
-                    <XAxis dataKey="date" stroke="#000" />
+                  <BarChart data={chartData} barGap={2}>
+                    <CartesianGrid strokeDasharray="3 3" stroke="#e5e5e5" vertical={false} />
+                    <XAxis dataKey="date" hide />
                     <YAxis stroke="#000" />
                     <Tooltip content={<ChartTooltipContent />} />
                     <Legend content={<ChartLegendContent />} />
-                    <Bar dataKey="hotel_guest" stackId="orders" fill="var(--color-hotel_guest)" />
                     <Bar dataKey="non_guest" stackId="orders" fill="var(--color-non_guest)" />
+                    <Bar dataKey="hotel_guest" stackId="orders" fill="var(--color-hotel_guest)" />
                   </BarChart>
                 </ResponsiveContainer>
               </ChartContainer>


### PR DESCRIPTION
## Summary
- extend `useOrdersByDate` hook to support revenue or count metrics
- show a date range picker and metric toggle in admin analytics chart
- display totals above the chart and style stacked bars
- update regular OrdersOverTime page to use new hook

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: missing @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_6855a32987a08320b4d725803fe9086b