### PR TITLE
Fix date range selection

### DIFF
--- a/src/pages/admin/analytics/OrdersOverTimeChart.tsx
+++ b/src/pages/admin/analytics/OrdersOverTimeChart.tsx
@@ -33,6 +33,15 @@ const OrdersOverTimeChart = () => {
     to: new Date(),
   })
 
+  const handleRangeSelect = (selected: DateRange | undefined) => {
+    if (!selected) return
+    if (selected.to && selected.from && selected.to < selected.from) {
+      setRange({ from: selected.to, to: selected.from })
+    } else {
+      setRange(selected)
+    }
+  }
+
   const endDate = range.to ? format(range.to, 'yyyy-MM-dd') : format(new Date(), 'yyyy-MM-dd')
   const startDate = range.from ? format(range.from, 'yyyy-MM-dd') : endDate
 
@@ -75,7 +84,7 @@ const OrdersOverTimeChart = () => {
                       mode="range"
                       defaultMonth={range.from}
                       selected={range}
-                      onSelect={setRange}
+                      onSelect={handleRangeSelect}
                       numberOfMonths={2}
                     />
                   </PopoverContent>


### PR DESCRIPTION
## Summary
- ensure selecting start date updates the range correctly by swapping from/to if needed

## Testing
- `npm run lint`
- `npx eslint src/pages/admin/analytics/OrdersOverTimeChart.tsx`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6855af98a4a88320a6f69223ccf3b86b