### PR TITLE
Update analytics function to ignore cancelled orders

### DIFF
--- a/supabase/migrations/20250621120000-remove-order-status-filter.sql
+++ b/supabase/migrations/20250621120000-remove-order-status-filter.sql
@@ -1,0 +1,24 @@
+-- Remove order_status filter so all orders are included
+CREATE OR REPLACE FUNCTION public.orders_by_day_and_guest_type(start_date DATE, end_date DATE)
+RETURNS TABLE(
+  order_date date,
+  guest_amount numeric,
+  non_guest_amount numeric
+)
+LANGUAGE sql
+AS $$
+  SELECT
+    date(o.created_at) AS order_date,
+    SUM(CASE WHEN p.customer_type = 'hotel_guest' THEN o.total_amount ELSE 0 END) AS guest_amount,
+    SUM(CASE WHEN p.customer_type = 'hotel_guest' THEN 0 ELSE o.total_amount END) AS non_guest_amount
+  FROM public.orders o
+  LEFT JOIN public.profiles p ON o.user_id = p.id
+  WHERE o.created_at >= start_date
+    AND o.created_at <= end_date
+  GROUP BY order_date
+  ORDER BY order_date DESC
+$$;
+
+-- Ensure the function owner is postgres and grant execute to authenticated users.
+ALTER FUNCTION public.orders_by_day_and_guest_type(DATE, DATE) OWNER TO postgres;
+GRANT EXECUTE ON FUNCTION public.orders_by_day_and_guest_type(DATE, DATE) TO authenticated;

--- a/supabase/migrations/20250621120500-exclude-cancelled-orders.sql
+++ b/supabase/migrations/20250621120500-exclude-cancelled-orders.sql
@@ -1,0 +1,25 @@
+-- Exclude cancelled orders in analytics
+CREATE OR REPLACE FUNCTION public.orders_by_day_and_guest_type(start_date DATE, end_date DATE)
+RETURNS TABLE(
+  order_date date,
+  guest_amount numeric,
+  non_guest_amount numeric
+)
+LANGUAGE sql
+AS $$
+  SELECT
+    date(o.created_at) AS order_date,
+    SUM(CASE WHEN p.customer_type = 'hotel_guest' THEN o.total_amount ELSE 0 END) AS guest_amount,
+    SUM(CASE WHEN p.customer_type = 'hotel_guest' THEN 0 ELSE o.total_amount END) AS non_guest_amount
+  FROM public.orders o
+  LEFT JOIN public.profiles p ON o.user_id = p.id
+  WHERE o.order_status <> 'cancelled'
+    AND o.created_at >= start_date
+    AND o.created_at <= end_date
+  GROUP BY order_date
+  ORDER BY order_date DESC
+$$;
+
+-- Ensure the function owner is postgres and grant execute to authenticated users.
+ALTER FUNCTION public.orders_by_day_and_guest_type(DATE, DATE) OWNER TO postgres;
+GRANT EXECUTE ON FUNCTION public.orders_by_day_and_guest_type(DATE, DATE) TO authenticated;


### PR DESCRIPTION
## Summary
- create new migration to exclude `cancelled` orders in `orders_by_day_and_guest_type`

## Testing
- `npm run lint` *(fails: many lint errors)*
- `npm run test` *(passes: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6856e955a9d88320a42106eca2fa5168