### PR TITLE
Add border to Orders Over Time tooltip indicators

### DIFF
--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -208,8 +208,8 @@ const ChartTooltipContent = React.forwardRef<
                           className={cn(
                             "shrink-0 rounded-[2px] border-[--color-border] bg-[--color-bg]",
                             {
-                              "h-2.5 w-2.5": indicator === "dot",
-                              "w-1": indicator === "line",
+                              "h-2.5 w-2.5 border-[0.5px]": indicator === "dot",
+                              "w-1 border-[0.5px]": indicator === "line",
                               "w-0 border-[1.5px] border-dashed bg-transparent":
                                 indicator === "dashed",
                               "my-0.5": nestLabel && indicator === "dashed",


### PR DESCRIPTION
## Summary
- tweak chart tooltip indicator styles to include a thin 0.5px border around the colored boxes

## Testing
- `npm run lint` *(fails: several existing lint errors)*
- `npm test` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6856f55227b48320bf530fe31cd59889