### PR TITLE
Update orders over time analytics display

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -7,6 +7,11 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 // Formats all prices without decimals
+
 export function formatThaiCurrency(amount: number): string {
   return `฿${Math.round(amount)}`;
+}
+
+export function formatThaiCurrencyWithComma(amount: number): string {
+  return `฿${Math.round(amount).toLocaleString()}`;
 }

--- a/src/pages/admin/analytics/OrdersOverTimeChart.tsx
+++ b/src/pages/admin/analytics/OrdersOverTimeChart.tsx
@@ -23,7 +23,7 @@ import {
 } from "@/components/ui/popover";
 import { Calendar } from "@/components/ui/calendar";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
-import { formatThaiCurrency } from "@/lib/utils";
+import { formatThaiCurrency, formatThaiCurrencyWithComma } from "@/lib/utils";
 
 import type { TooltipProps } from "recharts";
 
@@ -100,7 +100,7 @@ const OrdersOverTimeChart = () => {
           <CardHeader>
             <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
               <div className="flex items-center gap-2">
-                <CardTitle>Orders Over Time</CardTitle>
+                <CardTitle>Orders Over Time{' '}</CardTitle>
                 <ToggleGroup
                   type="single"
                   value={metric}
@@ -150,14 +150,13 @@ const OrdersOverTimeChart = () => {
               </div>
               <div className="text-lg font-bold md:ml-auto">
                 {metric === "revenue"
-                  ? formatThaiCurrency(total)
+                  ? formatThaiCurrencyWithComma(total)
                   : total.toLocaleString()}
                 <span className="ml-2 text-sm font-normal">
-                  Guest:
+                  Guest:{" "}
                   {metric === "revenue"
                     ? formatThaiCurrency(guestTotal)
-                    : guestTotal.toLocaleString()}
-                  {" "}Out:
+                    : guestTotal.toLocaleString()}{" "}Out:{" "}
                   {metric === "revenue"
                     ? formatThaiCurrency(outTotal)
                     : outTotal.toLocaleString()}


### PR DESCRIPTION
## Summary
- tweak spacing around the Orders Over Time heading
- show comma separated totals for revenue view
- add explicit spaces in Guest/Out values

## Testing
- `npm run lint` *(fails: '@typescript-eslint/no-require-imports' etc.)*
- `npm test` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6857912b9f0c83208439417d053da1b2