### PR TITLE
Fix spacing around Orders Over Time chart controls

### DIFF
--- a/src/pages/admin/analytics/OrdersOverTimeChart.tsx
+++ b/src/pages/admin/analytics/OrdersOverTimeChart.tsx
@@ -99,9 +99,10 @@ const OrdersOverTimeChart = () => {
         <Card className="bg-white text-black dark:bg-black dark:text-white border border-black">
           <CardHeader>
             <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-              <div className="flex items-center gap-2">
-                <CardTitle>Orders Over Time{' '}</CardTitle>
+              <div className="flex items-center">
+                <CardTitle>Orders Over Time </CardTitle>
                 <ToggleGroup
+                  className="gap-0"
                   type="single"
                   value={metric}
                   onValueChange={(val) =>


### PR DESCRIPTION
## Summary
- tweak Orders Over Time chart spacing

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6857941bcb248320a8077a5db4edb3ce