### PR TITLE
Update admin dashboard layout

### DIFF
--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -1,9 +1,8 @@
-
 import React from 'react';
 import { Link } from 'react-router-dom';
 import Layout from '@/components/layout/Layout';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardHeader, CardTitle } from '@/components/ui/card';
 import {
   Users,
   Package,
@@ -20,87 +19,59 @@ const Admin = () => {
         <div className="grid gap-4 mt-6 mb-8">
           <Link to="/orders-dashboard">
             <Card className="hover:shadow-md transition-shadow">
-              <CardHeader className="pb-2">
+              <CardHeader className="p-4">
                 <CardTitle className="flex items-center gap-2">
                   <ShoppingCart className="h-5 w-5" />
                   Orders Management
                 </CardTitle>
               </CardHeader>
-              <CardContent>
-                <p className="text-sm text-muted-foreground">Manage and track customer orders</p>
-              </CardContent>
             </Card>
           </Link>
           
           <Link to="/products-dashboard">
             <Card className="hover:shadow-md transition-shadow">
-              <CardHeader className="pb-2">
+              <CardHeader className="p-4">
                 <CardTitle className="flex items-center gap-2">
                   <Package className="h-5 w-5" />
                   Products Management
                 </CardTitle>
               </CardHeader>
-              <CardContent>
-                <p className="text-sm text-muted-foreground">Add, edit, and manage menu items</p>
-              </CardContent>
             </Card>
           </Link>
           
           <Link to="/categories-manager">
             <Card className="hover:shadow-md transition-shadow">
-              <CardHeader className="pb-2">
+              <CardHeader className="p-4">
                 <CardTitle className="flex items-center gap-2">
                   <LayoutGrid className="h-5 w-5" />
                   Categories Management
                 </CardTitle>
               </CardHeader>
-              <CardContent>
-                <p className="text-sm text-muted-foreground">Organize menu with categories</p>
-              </CardContent>
             </Card>
           </Link>
           
           <Link to="/customers-dashboard">
             <Card className="hover:shadow-md transition-shadow">
-              <CardHeader className="pb-2">
+              <CardHeader className="p-4">
                 <CardTitle className="flex items-center gap-2">
                   <Users className="h-5 w-5" />
                   Customer Management
                 </CardTitle>
               </CardHeader>
-              <CardContent>
-                <p className="text-sm text-muted-foreground">View and manage customer accounts</p>
-              </CardContent>
             </Card>
           </Link>
 
           <Link to="/admin/analytics/orders-over-time">
             <Card className="hover:shadow-md transition-shadow">
-              <CardHeader className="pb-2">
+              <CardHeader className="p-4">
                 <CardTitle className="flex items-center gap-2">
                   <BarChart className="h-5 w-5" />
                   Analytics
                 </CardTitle>
               </CardHeader>
-              <CardContent>
-                <p className="text-sm text-muted-foreground">View sales analytics</p>
-              </CardContent>
             </Card>
           </Link>
 
-          <Link to="/admin/analytics/orders-over-time">
-            <Card className="hover:shadow-md transition-shadow">
-              <CardHeader className="pb-2">
-                <CardTitle className="flex items-center gap-2">
-                  <BarChart className="h-5 w-5" />
-                  Orders Over Time
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="text-sm text-muted-foreground">View sales over time</p>
-              </CardContent>
-            </Card>
-          </Link>
         </div>
       </div>
     </Layout>


### PR DESCRIPTION
## Summary
- remove `Orders Over Time` card from admin dashboard
- drop block descriptions and shrink card padding

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685794aa889c8320996cae9473b4f7b9