### PR TITLE
style: border on tooltip indicators

### DIFF
--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -206,7 +206,7 @@ const ChartTooltipContent = React.forwardRef<
                       !hideIndicator && (
                         <div
                           className={cn(
-                            "shrink-0 rounded-[2px] border-[--color-border] bg-[--color-bg]",
+                            "shrink-0 rounded-[2px] border-black bg-[--color-bg]",
                             {
                               "h-2.5 w-2.5 border-[0.5px]": indicator === "dot",
                               "w-1 border-[0.5px]": indicator === "line",
@@ -218,7 +218,6 @@ const ChartTooltipContent = React.forwardRef<
                           style={
                             {
                               "--color-bg": indicatorColor,
-                              "--color-border": indicatorColor,
                             } as React.CSSProperties
                           }
                         />


### PR DESCRIPTION
## Summary
- tweak `ChartTooltipContent` to give tooltip color indicators a black border

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: vite not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6857a06c11c883208eef3954f372ea66