### PR TITLE
Add top products analytics card

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+{
+  "name": "Dine Merge Devcontainer",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:20",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "20"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "postCreateCommand": "npm install",
+  "forwardPorts": [5173],
+  "portsAttributes": {
+    "5173": { "label": "Vite" }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": ["dbaeumer.vscode-eslint"]
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ npm run dev
 - Click on "New codespace" to launch a new Codespace environment.
 - Edit files directly within the Codespace and commit and push your changes once you're done.
 
+### 🛠 Dev Setup
+
+This repo ships with a `.devcontainer` folder for a consistent Node.js 20 environment. The container automatically runs `npm install` on creation and forwards port **5173** for the Vite dev server.
+
+If Codespaces or Codex fails to start, open the Command Palette and choose **"Codespaces: Rebuild Container"**. Logs from the build will appear in the terminal if something goes wrong.
+
+The setup also recommends installing the `dbaeumer.vscode-eslint` extension so linting works out of the box.
+
 ## What technologies are used for this project?
 
 This project is built with:

--- a/src/hooks/useTopProductsByQuantity.ts
+++ b/src/hooks/useTopProductsByQuantity.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react'
+import { supabase } from '@/integrations/supabase/client'
+
+export type TopProductQuantity = {
+  product_name: string
+  hotel_guest_quantity: number
+  non_guest_quantity: number
+  total_quantity: number
+}
+
+export const useTopProductsByQuantity = (
+  startDate: string,
+  endDate: string,
+) => {
+  const [data, setData] = useState<TopProductQuantity[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const fetchData = async () => {
+      setIsLoading(true)
+      const { data, error } = await supabase.rpc('top_products_by_quantity', {
+        start_date: startDate,
+        end_date: endDate,
+      })
+      if (error) setError(error.message)
+      else setData((data ?? []) as TopProductQuantity[])
+      setIsLoading(false)
+    }
+    fetchData()
+  }, [startDate, endDate])
+
+  return { data, isLoading, error }
+}

--- a/src/pages/admin/analytics/OrdersOverTimeChart.tsx
+++ b/src/pages/admin/analytics/OrdersOverTimeChart.tsx
@@ -23,6 +23,15 @@ import {
 } from "@/components/ui/popover";
 import { Calendar } from "@/components/ui/calendar";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { useTopProductsByQuantity } from "@/hooks/useTopProductsByQuantity";
 import { formatThaiCurrency, formatThaiCurrencyWithComma } from "@/lib/utils";
 
 import type { TooltipProps } from "recharts";
@@ -57,6 +66,11 @@ const OrdersOverTimeChart = () => {
   const startDate = range.from ? format(range.from, "yyyy-MM-dd") : endDate;
 
   const { data, isLoading, error } = useOrdersByDate(startDate, endDate, metric);
+  const {
+    data: topProducts,
+    isLoading: isLoadingProducts,
+    error: errorProducts,
+  } = useTopProductsByQuantity(startDate, endDate);
 
   const chartData = [...data]
     .reverse()
@@ -218,6 +232,90 @@ const OrdersOverTimeChart = () => {
                   </BarChart>
                 </ResponsiveContainer>
               </ChartContainer>
+            )}
+          </CardContent>
+        </Card>
+        <Card className="mt-6 bg-white text-black dark:bg-black dark:text-white border border-black">
+          <CardHeader>
+            <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+              <div>
+                <CardTitle>Products by Orders</CardTitle>
+                <p className="text-sm text-muted-foreground">Top products by quantity sold by date</p>
+              </div>
+              <div className="flex items-center gap-2 pt-2 md:pt-0">
+                <Popover>
+                  <PopoverTrigger asChild>
+                    <Button variant="outline" className="text-sm font-normal w-[260px] justify-start">
+                      <CalendarIcon className="mr-2 h-4 w-4" />
+                      {range.from ? (
+                        range.to ? (
+                          <>
+                            {format(range.from, "LLL dd, y")} - {format(range.to, "LLL dd, y")}
+                          </>
+                        ) : (
+                          format(range.from, "LLL dd, y")
+                        )
+                      ) : (
+                        <span>Pick a date</span>
+                      )}
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent className="w-auto p-0" align="start">
+                    <Calendar
+                      initialFocus
+                      mode="range"
+                      defaultMonth={range.from}
+                      selected={range}
+                      onSelect={handleRangeSelect}
+                      numberOfMonths={2}
+                    />
+                  </PopoverContent>
+                </Popover>
+                <Button>Export</Button>
+              </div>
+            </div>
+          </CardHeader>
+          <CardContent className="p-4">
+            {isLoadingProducts ? (
+              <div className="p-6 text-center text-gray-500">Loading top products...</div>
+            ) : errorProducts ? (
+              <div className="p-6 text-center text-red-500">Failed to load products.</div>
+            ) : (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="text-left">Product</TableHead>
+                    <TableHead className="text-right">Guests</TableHead>
+                    <TableHead className="text-right">Non-Guests</TableHead>
+                    <TableHead className="text-right">Total</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {[...topProducts]
+                    .sort((a, b) => b.total_quantity - a.total_quantity)
+                    .map((product) => (
+                      <TableRow key={product.product_name}>
+                        <TableCell className="text-left">
+                          <a
+                            href="#"
+                            className="text-blue-600 hover:underline"
+                          >
+                            {product.product_name}
+                          </a>
+                        </TableCell>
+                        <TableCell className="text-right">
+                          {product.hotel_guest_quantity.toLocaleString()}
+                        </TableCell>
+                        <TableCell className="text-right">
+                          {product.non_guest_quantity.toLocaleString()}
+                        </TableCell>
+                        <TableCell className="text-right font-medium">
+                          {product.total_quantity.toLocaleString()}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                </TableBody>
+              </Table>
             )}
           </CardContent>
         </Card>


### PR DESCRIPTION
## Summary
- support VS Code ESLint extension in devcontainer
- document devcontainer usage under a new Dev Setup section
- fetch top products via `useTopProductsByQuantity`
- display a Products by Orders card with a date picker and export button

## Testing
- `npm run lint` *(fails: no-explicit-any, no-require-imports)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6857adb3a28c8320af7b8d27f8115961