### PR TITLE
Fix error state reset in top products hook

### DIFF
--- a/src/hooks/useTopProductsByQuantity.ts
+++ b/src/hooks/useTopProductsByQuantity.ts
@@ -19,6 +19,7 @@ export const useTopProductsByQuantity = (
   useEffect(() => {
     const fetchData = async () => {
       setIsLoading(true)
+      setError(null)
       const { data, error } = await supabase.rpc('top_products_by_quantity', {
         start_date: startDate,
         end_date: endDate,


### PR DESCRIPTION
## Summary
- clear error state before RPC call in `useTopProductsByQuantity`

## Testing
- `npm test -- -w=false` *(fails: No test files found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_6857cab7aefc8320ac86aabb30bd55b1