### PR TITLE
Remove Add Category text from button

### DIFF
--- a/src/pages/CategoriesManager.tsx
+++ b/src/pages/CategoriesManager.tsx
@@ -244,7 +244,6 @@ const CategoriesManager = () => {
                   setCategoryForm({ name: '', description: '' });
                 }}>
                   <Plus className="mr-2 h-4 w-4" />
-                  Add Category
                 </Button>
               </DialogTrigger>
               <DialogContent>


### PR DESCRIPTION
## Summary
- remove 'Add Category' text from the button in CategoriesManager

## Testing
- `npm test` *(fails: no test files)*

------
https://chatgpt.com/codex/tasks/task_e_68583c544dc48320ba2f257ec545cb7f