### PR TITLE
Adjust customer table columns

### DIFF
--- a/src/components/admin/CustomersList.tsx
+++ b/src/components/admin/CustomersList.tsx
@@ -60,8 +60,8 @@ const CustomersList: React.FC<CustomersListProps> = ({
           </TableHead>
           <TableHead>Name</TableHead>
           <TableHead className="hidden lg:table-cell">Role</TableHead>
+          <TableHead>Total</TableHead>
           <TableHead>Email</TableHead>
-          <TableHead>Total Spent</TableHead>
           <TableHead className="hidden md:table-cell">Phone</TableHead>
           <TableHead className="hidden lg:table-cell w-[150px]">Joined</TableHead>
           <TableHead><span className="sr-only">Actions</span></TableHead>
@@ -107,8 +107,8 @@ const CustomersList: React.FC<CustomersListProps> = ({
                   {customer.customer_type === 'hotel_guest' ? 'Guest' : 'Customer'}
                 </span>
               </TableCell>
-              <TableCell>{customer.email}</TableCell>
               <TableCell className="font-medium">{formatThaiCurrency(customer.total_spent)}</TableCell>
+              <TableCell>{customer.email}</TableCell>
               <TableCell className="hidden md:table-cell">{customer.phone || 'N/A'}</TableCell>
               <TableCell className="hidden lg:table-cell whitespace-nowrap">{format(new Date(customer.created_at), 'MMM d, yyyy')}</TableCell>
               <TableCell>


### PR DESCRIPTION
## Summary
- reorder customer list columns so 'Total' is between role and email
- rename column header from 'Total Spent' to 'Total'

## Testing
- `npm test -- --run` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68590474b67883208569ab472afcbfa1