### PR TITLE
Enable Orders dashboard link from analytics chart

### DIFF
--- a/src/pages/OrdersDashboard.tsx
+++ b/src/pages/OrdersDashboard.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import Layout from '@/components/layout/Layout';
 import { Card, CardContent } from '@/components/ui/card';
 import { useOrdersDashboard } from '@/hooks/useOrdersDashboard';
@@ -11,10 +12,10 @@ import StatusTabs from '@/components/admin/StatusTabs';
 const ALL_TAB = "all";
 
 const OrdersDashboard = () => {
-  const { 
-    orders, 
-    selectedOrders, 
-    isLoading, 
+  const {
+    orders,
+    selectedOrders,
+    isLoading,
     fetchOrders,
     updateOrderStatus,
     deleteSelectedOrders,
@@ -23,6 +24,9 @@ const OrdersDashboard = () => {
     selectAllOrders,
     clearSelection
   } = useOrdersDashboard();
+
+  const [searchParams] = useSearchParams();
+  const filterDate = searchParams.get('date');
 
   const [bulkStatus, setBulkStatus] = useState<OrderStatus | "">("");
   const [search, setSearch] = useState('');
@@ -44,6 +48,12 @@ const OrdersDashboard = () => {
 
   const filteredOrders = useMemo(() => {
     let filtered = orders;
+
+    if (filterDate) {
+      filtered = filtered.filter(order =>
+        order.created_at.split('T')[0] === filterDate
+      );
+    }
 
     if (search.trim()) {
       const s = search.trim().toLowerCase();
@@ -76,7 +86,7 @@ const OrdersDashboard = () => {
     }
 
     return filtered;
-  }, [orders, search, activeStatus]);
+  }, [orders, search, activeStatus, filterDate]);
 
   const tabOptions = [
     { label: "All", value: ALL_TAB },

--- a/src/pages/admin/analytics/OrdersOverTimeChart.tsx
+++ b/src/pages/admin/analytics/OrdersOverTimeChart.tsx
@@ -13,6 +13,7 @@ import {
 } from "recharts";
 import { useOrdersByDate } from "@/hooks/useOrdersByDate";
 import { format, subDays } from "date-fns";
+import { useNavigate } from "react-router-dom";
 import { DateRange } from "react-day-picker";
 import { CalendarIcon, ShoppingCart } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -54,6 +55,8 @@ const OrdersOverTimeChart = () => {
     from: new Date(),
     to: new Date(),
   });
+
+  const navigate = useNavigate();
 
   const handleChartRangeSelect = (selected: DateRange | undefined) => {
     if (!selected) return;
@@ -132,6 +135,13 @@ const OrdersOverTimeChart = () => {
   );
   const guestTotal = chartData.reduce((sum, row) => sum + row.hotel_guest, 0);
   const outTotal = chartData.reduce((sum, row) => sum + row.non_guest, 0);
+
+  const handleBarClick = (data: any) => {
+    const date = data.payload?.date;
+    if (date) {
+      navigate(`/orders-dashboard?date=${date}`);
+    }
+  };
 
   return (
     <Layout title="Orders Over Time" showBackButton>
@@ -247,6 +257,8 @@ const OrdersOverTimeChart = () => {
                       fill="var(--color-non_guest)"
                       stroke="#000"
                       strokeWidth={1}
+                      onClick={handleBarClick}
+                      className="cursor-pointer"
                     />
                     <Bar
                       dataKey="hotel_guest"
@@ -254,6 +266,8 @@ const OrdersOverTimeChart = () => {
                       fill="var(--color-hotel_guest)"
                       stroke="#000"
                       strokeWidth={1}
+                      onClick={handleBarClick}
+                      className="cursor-pointer"
                     />
                   </BarChart>
                 </ResponsiveContainer>


### PR DESCRIPTION
## Summary
- filter orders by `date` query string in Orders dashboard
- navigate to Orders dashboard when clicking analytics bar chart

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68591bfd68308320afd75412297d9717