### PR TITLE
Refactor: Improve admin orders analytics chart

### DIFF
--- a/src/hooks/useOrdersByDate.ts
+++ b/src/hooks/useOrdersByDate.ts
@@ -12,7 +12,6 @@ type OrdersByDate = {
 export const useOrdersByDate = (
   startDate: string,
   endDate: string,
-  metric: 'revenue' | 'count'
 ) => {
   const [data, setData] = useState<OrdersByDate[]>([])
   const [isLoading, setIsLoading] = useState(true)
@@ -31,7 +30,7 @@ export const useOrdersByDate = (
     }
 
     fetchData()
-  }, [startDate, endDate, metric])
+  }, [startDate, endDate])
 
   return { data, isLoading, error }
 }

--- a/src/pages/admin/analytics/OrdersOverTimeChart.tsx
+++ b/src/pages/admin/analytics/OrdersOverTimeChart.tsx
@@ -115,7 +115,6 @@ const OrdersOverTimeChart = () => {
   const { data, isLoading, error } = useOrdersByDate(
     chartStartDate,
     chartEndDate,
-    metric,
   );
   const {
     data: topProducts,
@@ -138,9 +137,9 @@ const OrdersOverTimeChart = () => {
   // Determine the max stacked value for a single day so the Y axis ticks can
   // be generated. For revenue we keep the existing thousands rounding while
   // the Orders view shows four ticks with values that are multiples of ten.
-  const maxValue = Math.max(
-    ...chartData.map((d) => d.hotel_guest + d.non_guest),
-  );
+  const maxValue = chartData.length > 0
+    ? Math.max(...chartData.map((d) => d.hotel_guest + d.non_guest))
+    : 0;
 
   const ticks = React.useMemo(() => {
     if (metric === "count") {


### PR DESCRIPTION
- Improves Y-axis tick calculation for empty chart data to prevent NaN errors.
- Optimizes the `useOrdersByDate` hook to prevent unnecessary API calls when toggling between revenue and count metrics, as the backend already provides all necessary data.