### PR TITLE
Configure GitGuardian pre-commit scan

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/GitGuardian/ggshield
+    rev: v1.41.0
+    hooks:
+      - id: ggshield
+        args: ["secret", "scan", "pre-commit"]


### PR DESCRIPTION
## Summary
- add .pre-commit-config.yaml using GitGuardian's ggshield
- update hook version via `pre-commit autoupdate`

## Testing
- `pre-commit run --all-files` *(fails: Invalid API key)*

------
https://chatgpt.com/codex/tasks/task_e_6860f8519ffc83209789c66d74864ce5