### PR TITLE
Add admin custom order section

### DIFF
--- a/src/components/admin/CustomOrderSection.tsx
+++ b/src/components/admin/CustomOrderSection.tsx
@@ -1,0 +1,86 @@
+import React, { useState } from 'react';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Plus, Minus, Trash2 } from 'lucide-react';
+import { createCustomOrder, CustomOrderItem } from '@/services/orderService';
+import { toast } from 'sonner';
+
+interface CustomOrderSectionProps {
+  customerId: string;
+  customerName: string | null;
+}
+
+const emptyItem = (): CustomOrderItem & { id: string } => ({
+  id: crypto.randomUUID(),
+  product: '',
+  price: 0,
+  quantity: 1,
+});
+
+const CustomOrderSection: React.FC<CustomOrderSectionProps> = ({ customerId, customerName }) => {
+  const [items, setItems] = useState<(CustomOrderItem & { id: string })[]>([]);
+  const [orderDate, setOrderDate] = useState<string>(new Date().toISOString().slice(0,10));
+  const addItem = () => setItems(prev => [...prev, emptyItem()]);
+  const removeItem = (id: string) => setItems(prev => prev.filter(i => i.id !== id));
+  const updateItem = (id: string, field: keyof CustomOrderItem, value: string | number) => {
+    setItems(prev => prev.map(i => i.id === id ? { ...i, [field]: value } : i));
+  };
+  const submit = async () => {
+    if (items.length === 0) return;
+    try {
+      await createCustomOrder(customerId, customerName, items.map(({id, ...rest}) => rest), new Date(orderDate).toISOString());
+      toast.success('Custom order created');
+      setItems([]);
+    } catch (e:any) {
+      console.error(e);
+      toast.error('Failed to create custom order');
+    }
+  };
+  return (
+    <Card className="p-4 mb-6 space-y-4">
+      <h3 className="text-lg font-semibold">Custom Order Items</h3>
+      <div className="space-y-4">
+        {items.map(item => (
+          <div key={item.id} className="flex gap-2 items-end">
+            <Input
+              placeholder="Name"
+              value={item.product}
+              onChange={e => updateItem(item.id, 'product', e.target.value)}
+              className="flex-1"
+            />
+            <div className="w-24">
+              <Input
+                type="number"
+                placeholder="Price"
+                value={item.price}
+                onChange={e => updateItem(item.id, 'price', Number(e.target.value))}
+              />
+            </div>
+            <div className="flex items-center gap-1">
+              <Button variant="outline" size="icon" onClick={() => updateItem(item.id, 'quantity', Math.max(1, item.quantity - 1))}>
+                <Minus className="w-4 h-4" />
+              </Button>
+              <span className="px-2">{item.quantity}</span>
+              <Button variant="outline" size="icon" onClick={() => updateItem(item.id, 'quantity', item.quantity + 1)}>
+                <Plus className="w-4 h-4" />
+              </Button>
+            </div>
+            <Button variant="ghost" size="icon" onClick={() => removeItem(item.id)}>
+              <Trash2 className="w-4 h-4" />
+            </Button>
+          </div>
+        ))}
+      </div>
+      <div className="flex items-center gap-2">
+        <Button type="button" variant="outline" onClick={addItem}>
+          Add custom item
+        </Button>
+        <Input type="date" value={orderDate} onChange={e => setOrderDate(e.target.value)} className="w-36" />
+        <Button onClick={submit} disabled={items.length === 0}>Submit Order</Button>
+      </div>
+    </Card>
+  );
+};
+
+export default CustomOrderSection;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -8,6 +8,7 @@ import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { Product } from '@/types/supabaseTypes';
 import { formatThaiCurrency } from '@/lib/utils';
+import CustomOrderSection from '@/components/admin/CustomOrderSection';
 
 interface Category {
   id: string;
@@ -102,6 +103,13 @@ const Index = () => {
               </div>
             </Card>
           </div>
+        )}
+
+        {currentUser?.role === 'admin' && adminCustomerContext && (
+          <CustomOrderSection
+            customerId={adminCustomerContext.customerId}
+            customerName={adminCustomerContext.customerName}
+          />
         )}
 
         {/* Categories with Black Headers */}

--- a/src/services/orderService.ts
+++ b/src/services/orderService.ts
@@ -74,6 +74,44 @@ export const placeOrderInSupabase = async (
   }
 };
 
+export type CustomOrderItem = {
+  product: string;
+  price: number;
+  quantity: number;
+};
+
+export const createCustomOrder = async (
+  customerId: string,
+  customerName: string | null,
+  items: CustomOrderItem[],
+  orderDate: string
+) => {
+  const total = items.reduce(
+    (sum, item) => sum + item.price * item.quantity,
+    0
+  );
+  const { data, error } = await supabase
+    .from('orders')
+    .insert({
+      user_id: customerId,
+      customer_name: customerName,
+      order_items: items as any,
+      total_amount: total,
+      order_status: 'completed',
+      created_at: orderDate,
+      updated_at: new Date().toISOString(),
+    })
+    .select()
+    .single();
+
+  if (error) {
+    console.error('Error creating custom order:', error);
+    throw error;
+  }
+
+  return data;
+};
+
 export const getFilteredOrderHistory = (orders: Order[], userId?: string) => {
   if (!userId) return [];
   return orders.filter(order => order.user_id === userId);


### PR DESCRIPTION
## Summary
- create `CustomOrderSection` component for admins to add custom items and submit order
- support custom order creation in `orderService`
- show custom order section on index page for admins ordering for a customer

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' and many lint errors)*
- `npm test` *(no test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68637f963d648320adff8a0a64ca2a2b