### PR TITLE
Update order cards to show custom item names

### DIFF
--- a/src/components/customer/CustomerOrderCard.tsx
+++ b/src/components/customer/CustomerOrderCard.tsx
@@ -59,7 +59,7 @@ const CustomerOrderCard = ({ order }: CustomerOrderCardProps) => {
         </div>
         <div className="mt-3 mb-3">
           {Array.isArray(order.order_items) && order.order_items.map((item: any, idx: number) => {
-            const name = item.name || (item.menuItem && item.menuItem.name) || "Item";
+            const name = item.product || item.name || (item.menuItem && item.menuItem.name) || "Item";
             const price = (typeof item.price === "number"
               ? item.price
               : item.menuItem && typeof item.menuItem.price === "number"

--- a/src/hooks/useFetchOrderById.ts
+++ b/src/hooks/useFetchOrderById.ts
@@ -46,7 +46,7 @@ export const useFetchOrderById = (orderId: string | undefined) => {
           // Fallback for any older data structures without menuItem
           return {
             id: item.id,
-            name: (item as any).name || 'Unknown Product',
+            name: (item as any).name || (item as any).product || 'Unknown Product',
             price: (item as any).price || 0,
             quantity: item.quantity,
             image_url: (item as any).image_url,

--- a/src/pages/AdminOrderDetail.tsx
+++ b/src/pages/AdminOrderDetail.tsx
@@ -121,7 +121,7 @@ const AdminOrderDetailContent = () => {
         {order.order_items?.map((item, index) => (
             <div key={item.id || index} className="space-y-1">
                 <div className="flex justify-between items-center text-base">
-                    <span>{item.quantity}x {item.name || 'Unknown Product'}</span>
+                    <span>{item.quantity}x {item.name || item.product || 'Unknown Product'}</span>
                     <span className="font-regular">
                     {formatThaiCurrency((item.price || 0) * item.quantity)}
                     </span>

--- a/src/pages/OrderConfirmation.tsx
+++ b/src/pages/OrderConfirmation.tsx
@@ -29,7 +29,8 @@ const OrderConfirmation = () => {
 
     const itemsDetails = order.order_items.map(item => {
       const optionsText = item.optionsString ? ` (${item.optionsString})` : '';
-      return `- ${item.quantity}x ${item.name}${optionsText}`;
+      const itemName = item.name || (item as any).product || 'Item';
+      return `- ${item.quantity}x ${itemName}${optionsText}`;
     }).join('\n');
 
     const customerName = order.customer_name || order.customer_name_from_profile || 'Guest';

--- a/src/pages/OrderHistory.tsx
+++ b/src/pages/OrderHistory.tsx
@@ -106,7 +106,7 @@ const OrderHistory = () => {
                   <div className="mt-3 mb-3">
                     {Array.isArray(order.order_items) && order.order_items.map((item: any, idx: number) => {
                       const hasMenuItem = item.menuItem && typeof item.menuItem === 'object';
-                      const name = hasMenuItem ? item.menuItem.name : (item.name || "Item");
+                      const name = hasMenuItem ? item.menuItem.name : (item.product || item.name || "Item");
                       const quantity = item.quantity || 1;
                       const selectedOptions = item.selectedOptions;
 

--- a/src/pages/OrdersDashboard.tsx
+++ b/src/pages/OrdersDashboard.tsx
@@ -59,8 +59,9 @@ const OrdersDashboard = () => {
         let containsProduct = false;
         if (Array.isArray(order.order_items)) {
           containsProduct = order.order_items.some((item: any) => {
-            if (typeof item?.name === 'string') {
-              return item.name.toLowerCase().includes(s);
+            const itemName = item.product || item.name;
+            if (typeof itemName === 'string') {
+              return itemName.toLowerCase().includes(s);
             }
             return false;
           });


### PR DESCRIPTION
## Summary
- handle `product` items throughout order summary components
- show fallback product names in WhatsApp order confirmation
- search by custom product names in dashboard

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686389bdde748320bded4fc03a287773