### PR TITLE
Add last order date to customers dashboard

### DIFF
--- a/src/components/admin/CustomersList.tsx
+++ b/src/components/admin/CustomersList.tsx
@@ -11,7 +11,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Profile } from '@/types/supabaseTypes';
 import { format } from 'date-fns';
 import { Button } from '@/components/ui/button';
-import { Edit, User, Mail, Phone, Calendar, CreditCard } from 'lucide-react';
+import { Edit, User, Mail, Calendar } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { Badge } from '@/components/ui/badge';
 import { formatThaiCurrencyWithComma } from '@/lib/utils';

--- a/src/components/admin/CustomersList.tsx
+++ b/src/components/admin/CustomersList.tsx
@@ -56,7 +56,7 @@ const CustomersList: React.FC<CustomersListProps> = ({
     }
   };
 
-  const handleAvatarUpdate = useCallback((customerId: string) => 
+  const handleAvatarUpdate = useCallback((customerId: string) =>
     (newAvatarUrl: string | null, newAvatarPath: string | null) => {
       if (onUpdateCustomer) {
         onUpdateCustomer(customerId, {
@@ -67,6 +67,18 @@ const CustomersList: React.FC<CustomersListProps> = ({
     },
     [onUpdateCustomer]
   );
+
+  const renderLastOrder = (date: string | null) => {
+    if (!date) {
+      return <div className="text-sm text-muted-foreground">&mdash;</div>;
+    }
+    return (
+      <div className="flex items-center text-sm text-muted-foreground">
+        <Calendar className="h-4 w-4 mr-2" />
+        {format(new Date(date), 'MMM d, yyyy \u2013 h:mm a')}
+      </div>
+    );
+  };
 
   if (customers.length === 0) {
     return (
@@ -161,15 +173,8 @@ const CustomersList: React.FC<CustomersListProps> = ({
                 <TableCell className="text-right">
                   {formatThaiCurrencyWithComma(customer.total_spent)}
                 </TableCell>
-                <TableCell className="hidden lg:table-cell">
-                  {customer.last_order_date ? (
-                    <div className="flex items-center">
-                      <Calendar className="h-4 w-4 mr-2 text-muted-foreground" />
-                      {format(new Date(customer.last_order_date), 'MMM d, yyyy \u2013 h:mm a')}
-                    </div>
-                  ) : (
-                    <div className="text-muted-foreground">&mdash;</div>
-                  )}
+                <TableCell className="hidden lg:table-cell text-sm text-muted-foreground">
+                  {renderLastOrder(customer.last_order_date)}
                 </TableCell>
                 <TableCell className="hidden lg:table-cell">
                   <div className="flex items-center">

--- a/src/components/admin/CustomersList.tsx
+++ b/src/components/admin/CustomersList.tsx
@@ -18,7 +18,13 @@ import { formatThaiCurrencyWithComma } from '@/lib/utils';
 import { ProfilePictureUploader } from './ProfilePictureUploader';
 
 interface CustomersListProps {
-  customers: (Profile & { total_spent: number; avatar_path?: string | null })[];
+  customers: (
+    Profile & {
+      total_spent: number
+      last_order_date: string | null
+      avatar_path?: string | null
+    }
+  )[];
   selectedCustomers: string[];
   toggleSelectCustomer: (customerId: string) => void;
   selectAllCustomers: (customerIds?: string[]) => void;
@@ -93,6 +99,7 @@ const CustomersList: React.FC<CustomersListProps> = ({
               <TableHead className="hidden md:table-cell">Status</TableHead>
               <TableHead className="hidden lg:table-cell">Email</TableHead>
               <TableHead className="text-right">Total</TableHead>
+              <TableHead className="hidden lg:table-cell">Last Order</TableHead>
               <TableHead className="hidden lg:table-cell">Joined</TableHead>
               <TableHead className="w-[50px]"></TableHead>
             </TableRow>
@@ -153,6 +160,16 @@ const CustomersList: React.FC<CustomersListProps> = ({
                 </TableCell>
                 <TableCell className="text-right">
                   {formatThaiCurrencyWithComma(customer.total_spent)}
+                </TableCell>
+                <TableCell className="hidden lg:table-cell">
+                  {customer.last_order_date ? (
+                    <div className="flex items-center">
+                      <Calendar className="h-4 w-4 mr-2 text-muted-foreground" />
+                      {format(new Date(customer.last_order_date), 'MMM d, yyyy \u2013 h:mm a')}
+                    </div>
+                  ) : (
+                    <div className="text-muted-foreground">&mdash;</div>
+                  )}
                 </TableCell>
                 <TableCell className="hidden lg:table-cell">
                   <div className="flex items-center">

--- a/src/hooks/useFetchCustomers.ts
+++ b/src/hooks/useFetchCustomers.ts
@@ -9,7 +9,9 @@ const MAX_RETRIES = 3;
 const RETRY_DELAY = 1000;
 
 export const useFetchCustomers = () => {
-  const [customers, setCustomers] = useState<(Profile & { total_spent: number })[]>([]);
+  const [customers, setCustomers] = useState<(
+    Profile & { total_spent: number; last_order_date: string | null }
+  )[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
 

--- a/src/types/supabaseTypes.ts
+++ b/src/types/supabaseTypes.ts
@@ -259,6 +259,7 @@ export type Database = {
           email: string
           customer_type: string
           total_spent: number
+          last_order_date: string | null
         }[]
       }
       get_orders_by_product: {

--- a/supabase/migrations/20250705000000_add_last_order_date.sql
+++ b/supabase/migrations/20250705000000_add_last_order_date.sql
@@ -1,0 +1,38 @@
+-- Add last_order_date to get_customers_with_total_spent function
+CREATE OR REPLACE FUNCTION public.get_customers_with_total_spent()
+RETURNS TABLE (
+  id uuid,
+  name text,
+  email text,
+  phone text,
+  role text,
+  customer_type text,
+  created_at timestamptz,
+  updated_at timestamptz,
+  total_spent numeric,
+  avatar_path text,
+  last_order_date timestamptz
+)
+LANGUAGE sql
+SECURITY DEFINER
+AS $$
+  SELECT
+    p.id,
+    p.name,
+    p.email,
+    p.phone,
+    p.role,
+    p.customer_type,
+    p.created_at,
+    p.updated_at,
+    COALESCE(SUM(o.total_amount), 0)::numeric(10,2) as total_spent,
+    p.avatar_path,
+    MAX(o.created_at) as last_order_date
+  FROM
+    public.profiles p
+    LEFT JOIN public.orders o ON p.id = o.user_id
+  GROUP BY
+    p.id
+  ORDER BY
+    p.name;
+$$;


### PR DESCRIPTION
## Summary
- track last order date via Supabase RPC
- expose `last_order_date` type from generated types
- fetch last order date in customers hook
- show a Last Order column on the dashboard

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68638bdc8db48320aa7f7e5fc2becead