### PR TITLE
Fix last order date crash

### DIFF
--- a/src/components/admin/CustomersList.tsx
+++ b/src/components/admin/CustomersList.tsx
@@ -17,13 +17,11 @@ import { Badge } from '@/components/ui/badge';
 import { formatThaiCurrencyWithComma } from '@/lib/utils';
 import { ProfilePictureUploader } from './ProfilePictureUploader';
 
-function renderLastOrder(date: string | null) {
+function renderLastOrder(date: string | null | undefined) {
   if (!date) return '—';
-  try {
-    return format(new Date(date), 'MMM d, yyyy – h:mm a');
-  } catch {
-    return 'Invalid Date';
-  }
+  const parsedDate = new Date(date);
+  if (isNaN(parsedDate.getTime())) return '—';
+  return format(parsedDate, 'MMM d, yyyy – h:mm a');
 }
 
 interface CustomersListProps {
@@ -172,7 +170,7 @@ const CustomersList: React.FC<CustomersListProps> = ({
                   {formatThaiCurrencyWithComma(customer.total_spent)}
                 </TableCell>
                 <TableCell className="hidden lg:table-cell text-sm text-muted-foreground">
-                  {renderLastOrder(customer.last_order_date)}
+                  {renderLastOrder(customer?.last_order_date)}
                 </TableCell>
                 <TableCell className="hidden lg:table-cell">
                   <div className="flex items-center">


### PR DESCRIPTION
## Summary
- handle invalid or undefined `last_order_date`
- safely render last order date

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68639a341a60832095b2441a25d9140e