### PR TITLE
Fix last order date display

### DIFF
--- a/src/components/admin/CustomersList.tsx
+++ b/src/components/admin/CustomersList.tsx
@@ -17,11 +17,17 @@ import { Badge } from '@/components/ui/badge';
 import { formatThaiCurrencyWithComma } from '@/lib/utils';
 import { ProfilePictureUploader } from './ProfilePictureUploader';
 
-function renderLastOrder(date: string | null | undefined) {
-  if (!date) return '—';
-  const parsedDate = new Date(date);
-  if (isNaN(parsedDate.getTime())) return '—';
-  return format(parsedDate, 'MMM d, yyyy – h:mm a');
+function renderLastOrder(date: unknown): string {
+  if (typeof date !== 'string') return '—';
+
+  try {
+    const parsed = new Date(date);
+    if (isNaN(parsed.getTime())) return '—';
+    return format(parsed, 'MMM d, yyyy – h:mm a');
+  } catch (err) {
+    console.error('Failed to format last_order_date:', date, err);
+    return '—';
+  }
 }
 
 interface CustomersListProps {


### PR DESCRIPTION
## Summary
- improve null safety around last_order_date rendering

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm test` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68639e0538048320b352f23982033698