### PR TITLE
Custom order price input styling

### DIFF
--- a/src/components/admin/CustomOrderSection.tsx
+++ b/src/components/admin/CustomOrderSection.tsx
@@ -55,12 +55,16 @@ const CustomOrderSection: React.FC<CustomOrderSectionProps> = ({ customerId, cus
               className="flex-1"
             />
             <div className="w-24">
-              <Input
-                type="number"
-                placeholder="Price"
-                value={item.price}
-                onChange={e => updateItem(item.id, 'price', Number(e.target.value))}
-              />
+              <div className="relative">
+                <span className="absolute left-0 inset-y-0 flex items-center pl-3 text-gray-500">฿</span>
+                <Input
+                  type="number"
+                  placeholder="Price"
+                  value={item.price}
+                  onChange={e => updateItem(item.id, 'price', Number(e.target.value))}
+                  className="pl-7 no-spinner"
+                />
+              </div>
             </div>
             <div className="flex items-center gap-1">
               <Button variant="outline" size="icon" onClick={() => updateItem(item.id, 'quantity', Math.max(1, item.quantity - 1))}>

--- a/src/index.css
+++ b/src/index.css
@@ -117,3 +117,13 @@
 .popular-badge {
   @apply absolute top-2 right-2 bg-black text-white text-xs px-2 py-1 rounded-sm;
 }
+
+/* Hide spinners on number inputs when using the `no-spinner` class */
+.no-spinner::-webkit-inner-spin-button,
+.no-spinner::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+.no-spinner {
+  -moz-appearance: textfield;
+}


### PR DESCRIPTION
## Summary
- show Thai baht sign in custom order price field
- hide number spinners on inputs using `.no-spinner` class

## Testing
- `npm test` *(fails: Playwright did not expect test.describe to be called)*
- `npm run lint` *(errors: Unexpected any, etc.)


------
https://chatgpt.com/codex/tasks/task_e_6863db467b7883209cb97037708a6b3c