### PR TITLE
Update custom order section form visibility

### DIFF
--- a/src/components/admin/CustomOrderSection.tsx
+++ b/src/components/admin/CustomOrderSection.tsx
@@ -43,54 +43,56 @@ const CustomOrderSection: React.FC<CustomOrderSectionProps> = ({ customerId, cus
     }
   };
   return (
-    <Card className="p-4 mb-6 space-y-4">
+    <Card className="p-4 mb-6">
       <div className="flex items-center justify-between">
         <h3 className="text-lg font-semibold">Custom Order</h3>
         <Button type="button" variant="outline" size="icon" onClick={addItem}>
           <Plus className="w-4 h-4" />
         </Button>
       </div>
-      <div className="space-y-4">
-        {items.map(item => (
-          <div key={item.id} className="flex gap-2 items-end">
-            <Input
-              placeholder="Name"
-              value={item.product}
-              onChange={e => updateItem(item.id, 'product', e.target.value)}
-              className="flex-1"
-            />
-            <div className="w-24">
-              <div className="relative">
-                <span className="absolute left-0 inset-y-0 flex items-center pl-3 text-gray-500">฿</span>
-                <Input
-                  type="number"
-                  placeholder="Price"
-                  value={item.price}
-                  onChange={e => updateItem(item.id, 'price', Number(e.target.value))}
-                  className="pl-7 no-spinner"
-                />
+      {items.length > 0 && (
+        <div className="mt-4 space-y-4 animate-in fade-in-0 slide-in-from-top-2 duration-200">
+          {items.map(item => (
+            <div key={item.id} className="flex gap-2 items-end">
+              <Input
+                placeholder="Name"
+                value={item.product}
+                onChange={e => updateItem(item.id, 'product', e.target.value)}
+                className="flex-1"
+              />
+              <div className="w-24">
+                <div className="relative">
+                  <span className="absolute left-0 inset-y-0 flex items-center pl-3 text-gray-500">฿</span>
+                  <Input
+                    type="number"
+                    placeholder="Price"
+                    value={item.price}
+                    onChange={e => updateItem(item.id, 'price', Number(e.target.value))}
+                    className="pl-7 no-spinner"
+                  />
+                </div>
               </div>
-            </div>
-            <div className="flex items-center gap-1">
-              <Button variant="outline" size="icon" onClick={() => updateItem(item.id, 'quantity', Math.max(1, item.quantity - 1))}>
-                <Minus className="w-4 h-4" />
+              <div className="flex items-center gap-1">
+                <Button variant="outline" size="icon" onClick={() => updateItem(item.id, 'quantity', Math.max(1, item.quantity - 1))}>
+                  <Minus className="w-4 h-4" />
+                </Button>
+                <span className="px-2">{item.quantity}</span>
+                <Button variant="outline" size="icon" onClick={() => updateItem(item.id, 'quantity', item.quantity + 1)}>
+                  <Plus className="w-4 h-4" />
+                </Button>
+              </div>
+              <Button variant="ghost" size="icon" onClick={() => removeItem(item.id)}>
+                <Trash2 className="w-4 h-4" />
               </Button>
-              <span className="px-2">{item.quantity}</span>
-              <Button variant="outline" size="icon" onClick={() => updateItem(item.id, 'quantity', item.quantity + 1)}>
-                <Plus className="w-4 h-4" />
-              </Button>
             </div>
-            <Button variant="ghost" size="icon" onClick={() => removeItem(item.id)}>
-              <Trash2 className="w-4 h-4" />
-            </Button>
+          ))}
+          <div className="flex items-center gap-2">
+            <Input type="date" value={orderDate} onChange={e => setOrderDate(e.target.value)} className="w-36" />
+            <Input type="time" value={orderTime} onChange={e => setOrderTime(e.target.value)} className="w-24" />
+            <Button onClick={submit} disabled={items.length === 0}>Order</Button>
           </div>
-        ))}
-      </div>
-      <div className="flex items-center gap-2">
-        <Input type="date" value={orderDate} onChange={e => setOrderDate(e.target.value)} className="w-36" />
-        <Input type="time" value={orderTime} onChange={e => setOrderTime(e.target.value)} className="w-24" />
-        <Button onClick={submit} disabled={items.length === 0}>Order</Button>
-      </div>
+        </div>
+      )}
     </Card>
   );
 };


### PR DESCRIPTION
## Summary
- only render custom order form after an item is added
- animate the form appearing with tailwind animations

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863e6b0cdcc832083b9222c4d70152f