### PR TITLE
Fix auth loading hang

### DIFF
--- a/src/components/AuthRedirect.tsx
+++ b/src/components/AuthRedirect.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
-import { useSupabaseAuth } from '@/hooks/useSupabaseAuth';
 import { useUserContext } from '@/context/UserContext';
 
 interface AuthRedirectProps {
@@ -10,21 +9,17 @@ interface AuthRedirectProps {
 const AuthRedirect: React.FC<AuthRedirectProps> = ({ children }) => {
   const navigate = useNavigate();
   const location = useLocation();
-  const { supabaseSession, isLoading: isAuthLoading } = useSupabaseAuth(() => Promise.resolve());
-  const { isLoading: isUserLoading } = useUserContext();
+  const { isLoggedIn, isLoading } = useUserContext();
 
   useEffect(() => {
-    if (!isAuthLoading && !isUserLoading) {
-      // If there's a session and the user is on the login page, redirect them
-      if (supabaseSession && location.pathname === '/login') {
-        const returnTo = new URLSearchParams(location.search).get('returnTo') || '/';
-        navigate(returnTo, { replace: true });
-      }
+    if (!isLoading && isLoggedIn && location.pathname === '/login') {
+      const returnTo = new URLSearchParams(location.search).get('returnTo') || '/';
+      navigate(returnTo, { replace: true });
     }
-  }, [supabaseSession, isAuthLoading, isUserLoading, navigate, location.pathname, location.search]);
+  }, [isLoading, isLoggedIn, navigate, location.pathname, location.search]);
 
   // Render children only after authentication state is determined
-  if (isAuthLoading || isUserLoading) {
+  if (isLoading) {
     return <div>Loading authentication...</div>; // Or a proper loading spinner
   }
 


### PR DESCRIPTION
## Summary
- streamline AuthRedirect to rely on `useUserContext`

## Testing
- `npm test` *(fails: expected "warn" to be called at least once)*
- `npm run lint` *(fails: unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_686515e936808320837650011c2191d3