### PR TITLE
Improve admin orders and login performance

### DIFF
--- a/app/admin/orders/page.tsx
+++ b/app/admin/orders/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useMemo, useEffect, Suspense } from 'react';
+import React, { useState, useEffect, Suspense } from 'react';
 import { useSearchParams } from 'next/navigation';
 import Layout from '@/components/layout/Layout';
 import { Card, CardContent } from '@/components/ui/card';
@@ -126,6 +126,20 @@ function OrdersDashboardContent() {
     }
   }, [customerParam, initialSearchSet]);
 
+  // Apply filters server-side with debounce to reduce load
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setFilters({
+        search: search.trim() || undefined,
+        status: activeStatus !== ALL_TAB ? activeStatus : undefined,
+        startDate: startDateParam || undefined,
+        endDate: endDateParam || undefined,
+      });
+    }, 300);
+
+    return () => clearTimeout(timer);
+  }, [search, activeStatus, startDateParam, endDateParam]);
+
   const handleBulkStatusChange = (value: OrderStatus) => {
     setBulkStatus(value);
     if (selectedOrders.length === 0) return;
@@ -139,62 +153,6 @@ function OrdersDashboardContent() {
       setActiveStatus(tabValue);
     }
   };
-
-  const filteredOrders = useMemo(() => {
-    let filtered = orders;
-
-    if (search.trim()) {
-      const s = search.trim().toLowerCase();
-      filtered = filtered.filter(order => {
-        const name = (order.customer_name_from_profile || order.customer_name || order.guest_first_name || "").toLowerCase();
-        const email = (order.customer_email_from_profile || "").toLowerCase();
-        const orderIdStr = String(order.id);
-        const stayId = (order.formattedStayId || '').toLowerCase();
-
-        let containsProduct = false;
-        if (Array.isArray(order.order_items)) {
-          containsProduct = order.order_items.some((item: any) => {
-            const itemName = item.product || item.name;
-            if (typeof itemName === 'string') {
-              return itemName.toLowerCase().includes(s);
-            }
-            return false;
-          });
-        }
-
-        return (
-          name.includes(s) ||
-          email.includes(s) ||
-          orderIdStr.includes(s) ||
-          containsProduct ||
-          stayId.includes(s)
-        );
-      });
-    }
-
-    if (activeStatus !== ALL_TAB) {
-      filtered = filtered.filter(order => order.order_status === activeStatus);
-    }
-
-    // Apply date-range filter from query params (inclusive)
-    if (startDateParam) {
-      const start = new Date(startDateParam);
-      filtered = filtered.filter(order => {
-        const d = new Date(order.created_at);
-        return d >= start;
-      });
-    }
-    if (endDateParam) {
-      const end = new Date(endDateParam);
-      end.setHours(23, 59, 59, 999);
-      filtered = filtered.filter(order => {
-        const d = new Date(order.created_at);
-        return d <= end;
-      });
-    }
-
-    return filtered;
-  }, [orders, search, activeStatus, startDateParam, endDateParam]);
 
   const tabOptions = [
     { label: "All", value: ALL_TAB },
@@ -232,12 +190,12 @@ function OrdersDashboardContent() {
               <div className="p-6 text-center text-muted-foreground">Loading orders...</div>
             ) : (
               <OrdersList 
-                orders={filteredOrders} 
+                orders={orders}
                 selectedOrders={selectedOrders}
                 toggleSelectOrder={toggleSelectOrder}
                 updateOrderStatus={updateOrderStatus}
                 orderStatusOptions={orderStatusOptions}
-                selectAllOrders={() => selectAllOrders(filteredOrders.map(o => o.id))}
+                selectAllOrders={() => selectAllOrders(orders.map(o => o.id))}
                 clearSelection={clearSelection}
                 onLoadMore={loadMore}
                 hasMore={hasMore}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,8 +1,4 @@
-'use client'
-
-'use client'
-
-import { usePathname } from 'next/navigation'
+import { headers } from 'next/headers'
 import './globals.css'
 import { Providers } from './providers'
 import GoogleAnalytics from '@/components/analytics/GoogleAnalytics'
@@ -11,16 +7,19 @@ import PWAProvider from '@/components/pwa/PWAProvider'
 import { SessionRecovery } from '@/components/SessionRecovery'
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
-  const pathname = usePathname();
-  const isAdminPath = pathname.startsWith('/admin') || pathname.startsWith('/login');
+  const headerList = headers()
+  const pathname = headerList.get('x-matched-path') ?? ''
+  const isAdminPath = pathname.startsWith('/admin')
+  const isLoginPath = pathname.startsWith('/login')
+  const skipSessionRecovery = isAdminPath || isLoginPath
 
   return (
     <html lang="en">
       <body>
         <GoogleAnalytics />
         <PWAProvider>
-          <Providers>
-            {!isAdminPath ? (
+          <Providers includeAppContext={!isLoginPath}>
+            {!skipSessionRecovery ? (
               <SessionRecovery>{children}</SessionRecovery>
             ) : (
               children

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -4,7 +4,7 @@ import React, { useState, Suspense } from 'react';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Layout from '@/components/layout/Layout';
-import { useAppContext } from '@/context/AppContext';
+import { useUserContext } from '@/context/UserContext';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -16,7 +16,7 @@ function LoginContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const returnTo = searchParams?.get('returnTo') || '/';
-  const { loginOrSignup, loginAsGuest } = useAppContext();
+  const { loginOrSignup, loginAsGuest } = useUserContext();
   const { toast } = useToast();
 
   const [name, setName] = useState('');

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -4,6 +4,7 @@ import { Toaster } from '@/components/ui/toaster'
 import { Toaster as Sonner } from '@/components/ui/sonner'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import AppContextProvider from '@/context/AppContextProvider'
+import { UserProvider } from '@/context/UserContext'
 
 // Optimized React Query configuration for better performance
 const queryClient = new QueryClient({
@@ -27,15 +28,17 @@ const queryClient = new QueryClient({
   },
 })
 
-export function Providers({ children }: { children: React.ReactNode }) {
+export function Providers({ children, includeAppContext = true }: { children: React.ReactNode; includeAppContext?: boolean }) {
   return (
     <QueryClientProvider client={queryClient}>
       <TooltipProvider>
-        <AppContextProvider>
-          {children}
-          <Toaster />
-          <Sonner />
-        </AppContextProvider>
+        {includeAppContext ? (
+          <AppContextProvider>{children}</AppContextProvider>
+        ) : (
+          <UserProvider>{children}</UserProvider>
+        )}
+        <Toaster />
+        <Sonner />
       </TooltipProvider>
     </QueryClientProvider>
   )

--- a/src/hooks/useFetchOrdersOptimized.ts
+++ b/src/hooks/useFetchOrdersOptimized.ts
@@ -128,10 +128,13 @@ export const useFetchOrdersOptimized = () => {
     };
   }, [resetAndFetch]);
 
-  const setFilters = (newFilters: FilterOptions) => {
-    filtersRef.current = newFilters;
-    resetAndFetch();
-  };
+  const setFilters = useCallback(
+    (newFilters: FilterOptions) => {
+      filtersRef.current = newFilters;
+      resetAndFetch();
+    },
+    [resetAndFetch]
+  );
 
   return {
     orders,


### PR DESCRIPTION
## Summary
- Fetch admin orders with server-side filters and debounce for snappier dashboard loads
- Skip heavyweight app context on login page by using header-based path detection in the root layout
- Allow Providers to render without AppContext for lightweight pages and update layout accordingly
- Prevent admin orders dashboard from refetching in a loop by stabilizing filter updates

## Testing
- `pnpm run build`
- `pnpm test run`


------
https://chatgpt.com/codex/tasks/task_e_689746b872ac8320957cd34a7865dcef