### PR TITLE
security(guests): server-side registration + revoke anon access to public.guests (C3)

### DIFF
--- a/app/api/guest/register/route.ts
+++ b/app/api/guest/register/route.ts
@@ -1,0 +1,81 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { createServiceRoleClient } from '@/lib/supabase-server';
+import {
+  registerGuest,
+  type GuestRegistrationStore,
+  type GuestRecord,
+} from '@/lib/guestRegistration';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from '@/types/supabaseTypes';
+
+export const runtime = 'nodejs';
+
+/**
+ * Adapts the service-role Supabase client to the GuestRegistrationStore port.
+ * All access to public.guests is service-role only; the browser no longer has
+ * SELECT/INSERT rights on this table (see the C3 migration).
+ */
+function createGuestStore(client: SupabaseClient<Database>): GuestRegistrationStore {
+  return {
+    async findByStayAndName(stayId, firstName) {
+      const { data, error } = await client
+        .from('guests')
+        .select('id, stay_id, first_name')
+        .eq('stay_id', stayId)
+        .eq('first_name', firstName)
+        .maybeSingle();
+
+      if (error) throw error;
+      return (data as GuestRecord) ?? null;
+    },
+
+    async countByStay(stayId) {
+      const { count, error } = await client
+        .from('guests')
+        .select('id', { count: 'exact', head: true })
+        .eq('stay_id', stayId);
+
+      if (error) throw error;
+      return count ?? 0;
+    },
+
+    async insert(row) {
+      const { data, error } = await client
+        .from('guests')
+        .insert(row)
+        .select('id, stay_id, first_name')
+        .single();
+
+      if (error) throw error;
+      return data as GuestRecord;
+    },
+  };
+}
+
+export async function POST(request: NextRequest) {
+  const serviceClient = createServiceRoleClient();
+  if (!serviceClient) {
+    return NextResponse.json({ error: 'Registration service unavailable' }, { status: 503 });
+  }
+
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON payload' }, { status: 400 });
+  }
+
+  let result;
+  try {
+    result = await registerGuest(payload, createGuestStore(serviceClient));
+  } catch (error) {
+    console.error('[api/guest/register] Unexpected failure:', error);
+    return NextResponse.json({ error: 'Failed to register guest' }, { status: 500 });
+  }
+
+  if (!result.ok) {
+    return NextResponse.json({ error: result.error }, { status: result.status });
+  }
+
+  return NextResponse.json(result.session, { status: result.status });
+}

--- a/app/api/guest/register/route.ts
+++ b/app/api/guest/register/route.ts
@@ -1,56 +1,9 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { createServiceRoleClient } from '@/lib/supabase-server';
-import {
-  registerGuest,
-  type GuestRegistrationStore,
-  type GuestRecord,
-} from '@/lib/guestRegistration';
-import type { SupabaseClient } from '@supabase/supabase-js';
-import type { Database } from '@/types/supabaseTypes';
+import { registerGuest } from '@/lib/guestRegistration';
+import { createSupabaseGuestStore } from '@/lib/guestRegistrationStore';
 
 export const runtime = 'nodejs';
-
-/**
- * Adapts the service-role Supabase client to the GuestRegistrationStore port.
- * All access to public.guests is service-role only; the browser no longer has
- * SELECT/INSERT rights on this table (see the C3 migration).
- */
-function createGuestStore(client: SupabaseClient<Database>): GuestRegistrationStore {
-  return {
-    async findByStayAndName(stayId, firstName) {
-      const { data, error } = await client
-        .from('guests')
-        .select('id, stay_id, first_name')
-        .eq('stay_id', stayId)
-        .eq('first_name', firstName)
-        .maybeSingle();
-
-      if (error) throw error;
-      return (data as GuestRecord) ?? null;
-    },
-
-    async countByStay(stayId) {
-      const { count, error } = await client
-        .from('guests')
-        .select('id', { count: 'exact', head: true })
-        .eq('stay_id', stayId);
-
-      if (error) throw error;
-      return count ?? 0;
-    },
-
-    async insert(row) {
-      const { data, error } = await client
-        .from('guests')
-        .insert(row)
-        .select('id, stay_id, first_name')
-        .single();
-
-      if (error) throw error;
-      return data as GuestRecord;
-    },
-  };
-}
 
 export async function POST(request: NextRequest) {
   const serviceClient = createServiceRoleClient();
@@ -67,7 +20,7 @@ export async function POST(request: NextRequest) {
 
   let result;
   try {
-    result = await registerGuest(payload, createGuestStore(serviceClient));
+    result = await registerGuest(payload, createSupabaseGuestStore(serviceClient));
   } catch (error) {
     console.error('[api/guest/register] Unexpected failure:', error);
     return NextResponse.json({ error: 'Failed to register guest' }, { status: 500 });

--- a/src/lib/guestRegistration.test.ts
+++ b/src/lib/guestRegistration.test.ts
@@ -123,6 +123,22 @@ describe('registerGuest', () => {
     expect(findSpy).not.toHaveBeenCalled();
   });
 
+  it('tolerates multiple historical rows for the same (stay, name): returns the first deterministic row, no insert', async () => {
+    // No unique constraint on (stay_id, first_name) — historical duplicates exist.
+    store.rows.push({ id: 'row-oldest', stay_id: 'A9_SZEMES', first_name: 'Bouke' });
+    store.rows.push({ id: 'row-newer', stay_id: 'A9_SZEMES', first_name: 'Bouke' });
+
+    const result = await registerGuest(
+      { first_name: 'Bouke', stay_id: 'A9_SZEMES', table_number: '12' },
+      store,
+      { generateId: seqIds() },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.ok && result.session.guest_user_id).toBe('row-oldest');
+    expect(store.insertCalls).toBe(0);
+  });
+
   it('is idempotent for a duplicate registration (same stay + name) and does not insert', async () => {
     store.rows.push({ id: 'existing-id', stay_id: 'A9_SZEMES', first_name: 'Bouke' });
     const result = await registerGuest(

--- a/src/lib/guestRegistration.test.ts
+++ b/src/lib/guestRegistration.test.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  MAX_GUESTS_PER_STAY,
+  parseGuestRegistrationRequest,
+  registerGuest,
+  type GuestRecord,
+  type GuestRegistrationStore,
+} from './guestRegistration';
+
+/** In-memory store that mimics the (stay_id, first_name) behaviour of public.guests. */
+class FakeGuestStore implements GuestRegistrationStore {
+  rows: GuestRecord[] = [];
+  insertCalls = 0;
+  // When true, the first insert throws a Postgres duplicate-key error.
+  raceDuplicate: GuestRecord | null = null;
+
+  async findByStayAndName(stayId: string, firstName: string): Promise<GuestRecord | null> {
+    return this.rows.find((r) => r.stay_id === stayId && r.first_name === firstName) ?? null;
+  }
+
+  async countByStay(stayId: string): Promise<number> {
+    return this.rows.filter((r) => r.stay_id === stayId).length;
+  }
+
+  async insert(row: { id: string; stay_id: string; first_name: string; table_number: string | null }): Promise<GuestRecord> {
+    this.insertCalls += 1;
+    if (this.raceDuplicate) {
+      const existing = this.raceDuplicate;
+      this.rows.push(existing); // another request won the race
+      this.raceDuplicate = null;
+      throw Object.assign(new Error('duplicate key value violates unique constraint'), { code: '23505' });
+    }
+    const created: GuestRecord = { id: row.id, stay_id: row.stay_id, first_name: row.first_name };
+    this.rows.push(created);
+    return created;
+  }
+}
+
+const seqIds = () => {
+  let n = 0;
+  return () => `id-${++n}`;
+};
+
+describe('parseGuestRegistrationRequest', () => {
+  it('rejects a missing or empty first name', () => {
+    expect(parseGuestRegistrationRequest({}).ok).toBe(false);
+    expect(parseGuestRegistrationRequest({ first_name: '   ' }).ok).toBe(false);
+  });
+
+  it('rejects non-object payloads', () => {
+    expect(parseGuestRegistrationRequest(null).ok).toBe(false);
+    expect(parseGuestRegistrationRequest('x').ok).toBe(false);
+  });
+
+  it('trims fields and treats a real stay_id as a hotel guest', () => {
+    const result = parseGuestRegistrationRequest({ first_name: '  Bouke ', stay_id: ' A9_SZEMES ', table_number: ' 12 ' });
+    expect(result).toEqual({ ok: true, value: { firstName: 'Bouke', stayId: 'A9_SZEMES', tableNumber: '12' } });
+  });
+
+  it('treats a missing stay_id as a walk-in (stayId null)', () => {
+    const result = parseGuestRegistrationRequest({ first_name: 'Nora', table_number: '7' });
+    expect(result.ok && result.value.stayId).toBeNull();
+  });
+
+  it('treats placeholder stay ids (unknown / walkin) as walk-ins', () => {
+    const unknown = parseGuestRegistrationRequest({ first_name: 'Nora', stay_id: 'unknown' });
+    const walkin = parseGuestRegistrationRequest({ first_name: 'Nora', stay_id: 'walkin-abc' });
+    expect(unknown.ok && unknown.value.stayId).toBeNull();
+    expect(walkin.ok && walkin.value.stayId).toBeNull();
+  });
+
+  it('enforces field length limits', () => {
+    expect(parseGuestRegistrationRequest({ first_name: 'a'.repeat(101) }).ok).toBe(false);
+    expect(parseGuestRegistrationRequest({ first_name: 'ok', stay_id: 'a'.repeat(129) }).ok).toBe(false);
+    expect(parseGuestRegistrationRequest({ first_name: 'ok', table_number: 'a'.repeat(129) }).ok).toBe(false);
+  });
+});
+
+describe('registerGuest', () => {
+  let store: FakeGuestStore;
+
+  beforeEach(() => {
+    store = new FakeGuestStore();
+  });
+
+  it('registers a new hotel QR guest and returns a session with the stay_id', async () => {
+    const result = await registerGuest(
+      { first_name: 'Bouke', stay_id: 'Beach_House_Rypma', table_number: 'Beach_House_Rypma' },
+      store,
+      { generateId: seqIds() },
+    );
+    expect(result.ok).toBe(true);
+    expect(result.ok && result.session).toEqual({
+      guest_user_id: 'id-1',
+      first_name: 'Bouke',
+      stay_id: 'Beach_House_Rypma',
+    });
+    expect(store.rows).toHaveLength(1);
+  });
+
+  it('registers a second family member (same stay, different name)', async () => {
+    store.rows.push({ id: 'existing', stay_id: 'Beach_House_Rypma', first_name: 'Bouke' });
+    const result = await registerGuest(
+      { first_name: 'Katja', stay_id: 'Beach_House_Rypma', table_number: 'Beach_House_Rypma' },
+      store,
+      { generateId: seqIds() },
+    );
+    expect(result.ok).toBe(true);
+    expect(result.ok && result.session.first_name).toBe('Katja');
+    expect(store.rows).toHaveLength(2);
+  });
+
+  it('registers a walk-in with a generated walkin-<uuid> stay_id and no pre-check', async () => {
+    const findSpy = vi.spyOn(store, 'findByStayAndName');
+    const result = await registerGuest(
+      { first_name: 'Agustina', table_number: '25' },
+      store,
+      { generateId: () => 'fixed-uuid' },
+    );
+    expect(result.ok).toBe(true);
+    expect(result.ok && result.session.stay_id).toBe('walkin-fixed-uuid');
+    // Walk-ins skip the existence pre-check entirely.
+    expect(findSpy).not.toHaveBeenCalled();
+  });
+
+  it('is idempotent for a duplicate registration (same stay + name) and does not insert', async () => {
+    store.rows.push({ id: 'existing-id', stay_id: 'A9_SZEMES', first_name: 'Bouke' });
+    const result = await registerGuest(
+      { first_name: 'Bouke', stay_id: 'A9_SZEMES', table_number: '12' },
+      store,
+      { generateId: seqIds() },
+    );
+    expect(result.ok).toBe(true);
+    expect(result.ok && result.session.guest_user_id).toBe('existing-id');
+    expect(store.insertCalls).toBe(0);
+  });
+
+  it('enforces the per-stay guest cap', async () => {
+    for (let i = 0; i < MAX_GUESTS_PER_STAY; i += 1) {
+      store.rows.push({ id: `g-${i}`, stay_id: 'FULL_STAY', first_name: `guest-${i}` });
+    }
+    const result = await registerGuest(
+      { first_name: 'OneTooMany', stay_id: 'FULL_STAY', table_number: '1' },
+      store,
+      { generateId: seqIds() },
+    );
+    expect(result.ok).toBe(false);
+    expect(!result.ok && result.status).toBe(429);
+    expect(store.insertCalls).toBe(0);
+  });
+
+  it('recovers from an insert race (23505) by returning the winning row', async () => {
+    store.raceDuplicate = { id: 'winner-id', stay_id: 'A9_SZEMES', first_name: 'Bouke' };
+    const result = await registerGuest(
+      { first_name: 'Bouke', stay_id: 'A9_SZEMES', table_number: '12' },
+      store,
+      { generateId: seqIds() },
+    );
+    expect(result.ok).toBe(true);
+    expect(result.ok && result.session.guest_user_id).toBe('winner-id');
+  });
+
+  it('rejects invalid input before touching the store', async () => {
+    const result = await registerGuest({ first_name: '' }, store, { generateId: seqIds() });
+    expect(result.ok).toBe(false);
+    expect(!result.ok && result.status).toBe(400);
+    expect(store.insertCalls).toBe(0);
+  });
+});

--- a/src/lib/guestRegistration.ts
+++ b/src/lib/guestRegistration.ts
@@ -40,7 +40,14 @@ export interface GuestRecord {
  * service-role Supabase client; tests implement it in memory.
  */
 export interface GuestRegistrationStore {
-  /** Exact match on (stay_id, first_name); null when no such guest exists. */
+  /**
+   * Match on (stay_id, first_name); null when no such guest exists.
+   *
+   * (stay_id, first_name) has no unique constraint and historical data may hold
+   * several matching rows, so implementations MUST tolerate duplicates and
+   * return a single deterministic canonical row (e.g. earliest created_at, then
+   * id) rather than erroring.
+   */
   findByStayAndName(stayId: string, firstName: string): Promise<GuestRecord | null>;
   /** Number of guest rows already registered under a stay_id. */
   countByStay(stayId: string): Promise<number>;

--- a/src/lib/guestRegistration.ts
+++ b/src/lib/guestRegistration.ts
@@ -1,0 +1,193 @@
+/**
+ * Server-side guest registration logic (C3).
+ *
+ * Guest rows in `public.guests` are no longer created directly by the browser.
+ * The anon/authenticated roles have no SELECT/INSERT access to the table; all
+ * registration goes through POST /api/guest/register, which runs with the
+ * service-role client and delegates the decision logic to `registerGuest`
+ * below.
+ *
+ * This module is deliberately free of any Supabase import so the branching
+ * behaviour (hotel guest, second family member, walk-in, duplicate
+ * registration, and the per-stay cap) can be unit-tested against an in-memory
+ * store.
+ */
+
+/** Maximum number of guests that may register under a single hotel stay_id. */
+export const MAX_GUESTS_PER_STAY = 25;
+
+/** Upper bounds on the free-text fields accepted from the client. */
+export const MAX_FIRST_NAME_LENGTH = 100;
+export const MAX_STAY_ID_LENGTH = 128;
+export const MAX_TABLE_NUMBER_LENGTH = 128;
+
+/** Session fields returned to the browser (mirrors GuestSession in guestSession.ts). */
+export interface GuestSessionResponse {
+  guest_user_id: string;
+  first_name: string;
+  stay_id: string;
+}
+
+/** Minimal guest record shape used internally. */
+export interface GuestRecord {
+  id: string;
+  stay_id: string;
+  first_name: string;
+}
+
+/**
+ * Data-access port for `registerGuest`. The route implements this over the
+ * service-role Supabase client; tests implement it in memory.
+ */
+export interface GuestRegistrationStore {
+  /** Exact match on (stay_id, first_name); null when no such guest exists. */
+  findByStayAndName(stayId: string, firstName: string): Promise<GuestRecord | null>;
+  /** Number of guest rows already registered under a stay_id. */
+  countByStay(stayId: string): Promise<number>;
+  /** Insert a new guest row. May throw a Postgres duplicate-key error (code 23505). */
+  insert(row: {
+    id: string;
+    stay_id: string;
+    first_name: string;
+    table_number: string | null;
+  }): Promise<GuestRecord>;
+}
+
+export interface ParsedRegistration {
+  firstName: string;
+  /** null => walk-in guest (server generates a walkin-<uuid> stay_id). */
+  stayId: string | null;
+  tableNumber: string | null;
+}
+
+export type RegistrationFailure = { ok: false; status: number; error: string };
+export type ParseResult = { ok: true; value: ParsedRegistration } | RegistrationFailure;
+export type RegisterResult =
+  | { ok: true; status: number; session: GuestSessionResponse }
+  | RegistrationFailure;
+
+interface RegisterOptions {
+  generateId?: () => string;
+}
+
+const asTrimmedString = (value: unknown): string | null => {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length ? trimmed : null;
+};
+
+/** True for placeholder stay ids the client uses to mean "no real hotel stay". */
+const isWalkInPlaceholder = (stayId: string): boolean => {
+  const lowered = stayId.toLowerCase();
+  return lowered === 'unknown' || lowered.includes('walkin');
+};
+
+/**
+ * Validate and normalise a raw request body into a ParsedRegistration.
+ * A missing / empty / placeholder stay_id resolves to a walk-in (stayId: null).
+ */
+export function parseGuestRegistrationRequest(body: unknown): ParseResult {
+  if (typeof body !== 'object' || body === null) {
+    return { ok: false, status: 400, error: 'Invalid registration payload' };
+  }
+
+  const record = body as Record<string, unknown>;
+
+  const firstName = asTrimmedString(record.first_name);
+  if (!firstName) {
+    return { ok: false, status: 400, error: 'First name is required' };
+  }
+  if (firstName.length > MAX_FIRST_NAME_LENGTH) {
+    return { ok: false, status: 400, error: 'First name is too long' };
+  }
+
+  const rawStayId = asTrimmedString(record.stay_id);
+  let stayId: string | null = rawStayId;
+  if (rawStayId) {
+    if (rawStayId.length > MAX_STAY_ID_LENGTH) {
+      return { ok: false, status: 400, error: 'Stay id is too long' };
+    }
+    // Placeholder stay ids are treated as walk-ins, never as a hotel family.
+    if (isWalkInPlaceholder(rawStayId)) {
+      stayId = null;
+    }
+  }
+
+  const tableNumber = asTrimmedString(record.table_number);
+  if (tableNumber && tableNumber.length > MAX_TABLE_NUMBER_LENGTH) {
+    return { ok: false, status: 400, error: 'Table number is too long' };
+  }
+
+  return { ok: true, value: { firstName, stayId, tableNumber } };
+}
+
+const sessionFrom = (guest: GuestRecord): GuestSessionResponse => ({
+  guest_user_id: guest.id,
+  first_name: guest.first_name,
+  stay_id: guest.stay_id,
+});
+
+const hasPostgresCode = (error: unknown, code: string): boolean =>
+  typeof error === 'object' &&
+  error !== null &&
+  (error as { code?: unknown }).code === code;
+
+/**
+ * Register a guest, preserving the behaviour of the old client-side
+ * createGuestUser:
+ *  - hotel guest: reuse an existing (stay_id, first_name) row if present,
+ *    otherwise insert (subject to the per-stay cap);
+ *  - second family member: a different first_name on the same stay_id inserts
+ *    a new row;
+ *  - walk-in: no stay_id supplied -> server generates a unique walkin-<uuid>
+ *    stay_id and inserts, with no existence pre-check;
+ *  - duplicate registration: same (stay_id, first_name), including an insert
+ *    that races into a 23505, returns the existing row idempotently.
+ */
+export async function registerGuest(
+  body: unknown,
+  store: GuestRegistrationStore,
+  options: RegisterOptions = {},
+): Promise<RegisterResult> {
+  const parsed = parseGuestRegistrationRequest(body);
+  if (!parsed.ok) return parsed;
+
+  const generateId = options.generateId ?? (() => crypto.randomUUID());
+  const { firstName, stayId, tableNumber } = parsed.value;
+  const isHotelGuest = stayId !== null;
+  const finalStayId = stayId ?? `walkin-${generateId()}`;
+
+  if (isHotelGuest) {
+    const existing = await store.findByStayAndName(finalStayId, firstName);
+    if (existing) {
+      return { ok: true, status: 200, session: sessionFrom(existing) };
+    }
+
+    const existingCount = await store.countByStay(finalStayId);
+    if (existingCount >= MAX_GUESTS_PER_STAY) {
+      return {
+        ok: false,
+        status: 429,
+        error: 'This stay already has the maximum number of registered guests. Please ask our staff for help.',
+      };
+    }
+  }
+
+  try {
+    const created = await store.insert({
+      id: generateId(),
+      stay_id: finalStayId,
+      first_name: firstName,
+      table_number: tableNumber,
+    });
+    return { ok: true, status: 201, session: sessionFrom(created) };
+  } catch (error) {
+    if (isHotelGuest && hasPostgresCode(error, '23505')) {
+      const existing = await store.findByStayAndName(finalStayId, firstName);
+      if (existing) {
+        return { ok: true, status: 200, session: sessionFrom(existing) };
+      }
+    }
+    return { ok: false, status: 500, error: 'Failed to register guest' };
+  }
+}

--- a/src/lib/guestRegistrationStore.test.ts
+++ b/src/lib/guestRegistrationStore.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from '@/types/supabaseTypes';
+import { createSupabaseGuestStore } from './guestRegistrationStore';
+
+type QueryResult = { data?: unknown; count?: number; error?: unknown };
+
+/**
+ * Minimal chainable Supabase query-builder mock. Every builder method records
+ * its name and returns the same thenable builder, which resolves to `result`
+ * when awaited. `maybeSingle` throws so a regression to it is caught.
+ */
+function createMockClient(result: QueryResult) {
+  const methods: string[] = [];
+  const builder: Record<string, unknown> = {};
+  const passthrough = (name: string) => (..._args: unknown[]) => {
+    methods.push(name);
+    return builder;
+  };
+
+  builder.select = passthrough('select');
+  builder.eq = passthrough('eq');
+  builder.order = passthrough('order');
+  builder.limit = passthrough('limit');
+  builder.insert = passthrough('insert');
+  builder.single = () => {
+    methods.push('single');
+    return Promise.resolve(result);
+  };
+  builder.maybeSingle = () => {
+    methods.push('maybeSingle');
+    throw new Error('maybeSingle must not be used: (stay_id, first_name) is not unique');
+  };
+  // Make the builder awaitable (PostgREST builders are thenables).
+  builder.then = (resolve: (v: QueryResult) => unknown, reject?: (e: unknown) => unknown) =>
+    Promise.resolve(result).then(resolve, reject);
+
+  const client = {
+    from: (_table: string) => {
+      methods.push('from');
+      return builder;
+    },
+  } as unknown as SupabaseClient<Database>;
+
+  return { client, methods };
+}
+
+describe('createSupabaseGuestStore.findByStayAndName', () => {
+  it('does not error on multiple historical rows and returns the first deterministic row', async () => {
+    // Two rows share (stay_id, first_name); the query orders + limits to 1.
+    const { client, methods } = createMockClient({
+      data: [
+        { id: 'row-oldest', stay_id: 'A9_SZEMES', first_name: 'Bouke' },
+        { id: 'row-newer', stay_id: 'A9_SZEMES', first_name: 'Bouke' },
+      ],
+      error: null,
+    });
+
+    const store = createSupabaseGuestStore(client);
+    const result = await store.findByStayAndName('A9_SZEMES', 'Bouke');
+
+    expect(result).toEqual({ id: 'row-oldest', stay_id: 'A9_SZEMES', first_name: 'Bouke' });
+    // Proves the fix: deterministic ordering + limit, and NOT .maybeSingle().
+    expect(methods).toContain('order');
+    expect(methods).toContain('limit');
+    expect(methods).not.toContain('maybeSingle');
+  });
+
+  it('returns null when no rows match', async () => {
+    const { client } = createMockClient({ data: [], error: null });
+    const store = createSupabaseGuestStore(client);
+    expect(await store.findByStayAndName('NOPE', 'Ghost')).toBeNull();
+  });
+
+  it('propagates a query error', async () => {
+    const { client } = createMockClient({ data: null, error: { message: 'boom' } });
+    const store = createSupabaseGuestStore(client);
+    await expect(store.findByStayAndName('A9', 'Bouke')).rejects.toBeTruthy();
+  });
+});

--- a/src/lib/guestRegistrationStore.ts
+++ b/src/lib/guestRegistrationStore.ts
@@ -1,0 +1,55 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from '@/types/supabaseTypes';
+import type { GuestRecord, GuestRegistrationStore } from './guestRegistration';
+
+/**
+ * Service-role-backed implementation of GuestRegistrationStore over public.guests.
+ *
+ * NOTE on findByStayAndName: (stay_id, first_name) has no unique constraint and
+ * historical data can contain several matching rows, so we must NOT use
+ * .maybeSingle() (which errors on >1 row). Instead we order deterministically
+ * (created_at, then id) and take the first row, so idempotent re-registration
+ * always resolves to the same canonical guest row instead of 500-ing.
+ */
+export function createSupabaseGuestStore(
+  client: SupabaseClient<Database>,
+): GuestRegistrationStore {
+  return {
+    async findByStayAndName(stayId, firstName) {
+      const { data, error } = await client
+        .from('guests')
+        .select('id, stay_id, first_name')
+        .eq('stay_id', stayId)
+        .eq('first_name', firstName)
+        .order('created_at', { ascending: true })
+        .order('id', { ascending: true })
+        .limit(1);
+
+      if (error) throw error;
+
+      const rows = (data as GuestRecord[] | null) ?? [];
+      return rows[0] ?? null;
+    },
+
+    async countByStay(stayId) {
+      const { count, error } = await client
+        .from('guests')
+        .select('id', { count: 'exact', head: true })
+        .eq('stay_id', stayId);
+
+      if (error) throw error;
+      return count ?? 0;
+    },
+
+    async insert(row) {
+      const { data, error } = await client
+        .from('guests')
+        .insert(row)
+        .select('id, stay_id, first_name')
+        .single();
+
+      if (error) throw error;
+      return data as GuestRecord;
+    },
+  };
+}

--- a/src/utils/guestSession.test.ts
+++ b/src/utils/guestSession.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createGuestUser, getGuestSession } from './guestSession';
+
+describe('createGuestUser (server-mediated registration)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('POSTs to /api/guest/register and persists the returned session in localStorage', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => ({
+        guest_user_id: 'guest-123',
+        first_name: 'Bouke',
+        stay_id: 'Beach_House_Rypma',
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const session = await createGuestUser({
+      table_number: 'Beach_House_Rypma',
+      first_name: 'Bouke',
+      stay_id: 'Beach_House_Rypma',
+    });
+
+    // Called the server route, never the Supabase table directly.
+    expect(fetchMock).toHaveBeenCalledWith('/api/guest/register', expect.objectContaining({ method: 'POST' }));
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+    expect(body).toEqual({ first_name: 'Bouke', stay_id: 'Beach_House_Rypma', table_number: 'Beach_House_Rypma' });
+
+    // Preserves the existing GuestSession shape.
+    expect(session).toEqual({
+      guest_user_id: 'guest-123',
+      guest_first_name: 'Bouke',
+      guest_stay_id: 'Beach_House_Rypma',
+    });
+
+    // localStorage keys are unchanged so existing sessions stay compatible.
+    expect(localStorage.getItem('guest_user_id')).toBe('guest-123');
+    expect(localStorage.getItem('guest_first_name')).toBe('Bouke');
+    expect(localStorage.getItem('guest_stay_id')).toBe('Beach_House_Rypma');
+    expect(localStorage.getItem('table_number_pending')).toBe('Beach_House_Rypma');
+
+    expect(getGuestSession()).toEqual(session);
+  });
+
+  it('throws with the server-provided error message on a failed registration', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 429,
+        json: async () => ({ error: 'This stay already has the maximum number of registered guests. Please ask our staff for help.' }),
+      }),
+    );
+
+    await expect(
+      createGuestUser({ table_number: '1', first_name: 'Nora', stay_id: 'FULL_STAY' }),
+    ).rejects.toThrow('maximum number of registered guests');
+
+    expect(localStorage.getItem('guest_user_id')).toBeNull();
+  });
+});

--- a/src/utils/guestSession.ts
+++ b/src/utils/guestSession.ts
@@ -8,8 +8,6 @@
  * Includes PWA standalone mode detection and session recovery.
  */
 
-import { supabase } from '@/integrations/supabase/client';
-
 /**
  * GuestSession interface for managing guest user sessions
  * stay_id is either a hotel stay (e.g. '3A12') or 'walkin-<guest_user_id>' for walk-in guests
@@ -174,120 +172,54 @@ export function getTableNumber(): string | null {
 }
 
 export async function createGuestUser({ table_number, first_name = 'Guest', stay_id }: { table_number: string; first_name?: string; stay_id?: string }): Promise<GuestSession> {
-  const randomId = crypto.randomUUID();
-  
-  // If stay_id is provided (hotel guest), use it. Otherwise, create walkin stay_id
-  const finalStayId = stay_id || `walkin-${randomId}`;
-  
-  console.log('[createGuestUser] Creating guest user with:', { 
-    randomId, 
-    first_name, 
-    table_number, 
-    provided_stay_id: stay_id,
-    finalStayId 
-  });
-  
-  // Performance optimization: Check if user already exists to avoid duplicate inserts
-  if (stay_id) {
-    try {
-      const { data: existingUser, error: existingError } = await supabase
-        .from('guests')
-        .select('id as user_id, first_name, stay_id')
-        .eq('stay_id', finalStayId)
-        .eq('first_name', first_name)
-        .single();
-      
-      if (existingUser && !existingError) {
-        console.log('[createGuestUser] User already exists, returning existing session:', existingUser);
-        const session = {
-          guest_user_id: existingUser.user_id,
-          guest_first_name: existingUser.first_name,
-          guest_stay_id: existingUser.stay_id
-        };
-        
-        try {
-          saveGuestSession(session);
-          setTableNumber(table_number);
-          console.log('[createGuestUser] Session saved successfully:', session);
-        } catch (storageError) {
-          console.warn('[createGuestUser] Failed to save session to localStorage:', storageError);
-        }
-        
-        return session;
-      }
-    } catch (checkError) {
-      console.log('[createGuestUser] Error checking existing user (proceeding with insert):', checkError);
-    }
-  }
-  
-  // Insert the guest user with final stay_id to avoid update query
-  const { data, error } = await supabase.from('guests').insert({
-    id: randomId,
+  // Guest rows are created server-side. The browser no longer has direct
+  // SELECT/INSERT access to public.guests (C3); POST /api/guest/register runs
+  // with the service-role client and applies the hotel / second-family-member /
+  // walk-in / duplicate-registration and per-stay cap rules.
+  console.log('[createGuestUser] Registering guest via /api/guest/register:', {
     first_name,
-    stay_id: finalStayId,
-    table_number
-  }).select();
-  
-  if (error) {
-    console.error('[createGuestUser] Insert error:', error);
-    // Handle common duplicate key errors gracefully
-    if (error.code === '23505') { // PostgreSQL duplicate key error
-      console.log('[createGuestUser] Duplicate key error, attempting to fetch existing user');
-      try {
-        const { data: existingUser } = await supabase
-          .from('guests')
-          .select('id as user_id, first_name, stay_id')
-          .eq('stay_id', finalStayId)
-          .eq('first_name', first_name)
-          .single();
-        
-        if (existingUser) {
-          const session = {
-            guest_user_id: existingUser.user_id,
-            guest_first_name: existingUser.first_name,
-            guest_stay_id: existingUser.stay_id
-          };
-          
-          try {
-            saveGuestSession(session);
-            setTableNumber(table_number);
-            console.log('[createGuestUser] Session saved successfully:', session);
-          } catch (storageError) {
-            console.warn('[createGuestUser] Failed to save session to localStorage:', storageError);
-          }
-          
-          return session;
-        }
-      } catch (fetchError) {
-        console.error('[createGuestUser] Failed to fetch existing user after duplicate key error:', fetchError);
-      }
-    }
-    throw error;
+    table_number,
+    provided_stay_id: stay_id,
+  });
+
+  const response = await fetch('/api/guest/register', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      first_name,
+      stay_id,
+      table_number,
+    }),
+  });
+
+  const payload = await response.json().catch(() => ({} as Record<string, unknown>));
+
+  if (!response.ok) {
+    const message = typeof payload?.error === 'string' ? payload.error : 'Failed to register guest';
+    console.error('[createGuestUser] Registration failed:', { status: response.status, message });
+    throw new Error(message);
   }
-  
-  if (!data || data.length === 0) {
-    console.error('[createGuestUser] No data returned from insert');
+
+  const session: GuestSession = {
+    guest_user_id: payload.guest_user_id,
+    guest_first_name: payload.first_name,
+    guest_stay_id: payload.stay_id,
+  };
+
+  if (!session.guest_user_id || !session.guest_stay_id) {
+    console.error('[createGuestUser] Registration response missing fields:', payload);
     throw new Error('Failed to create guest user: no data returned');
   }
-  
-  const insertedUser = data[0];
-  console.log('[createGuestUser] User inserted successfully:', insertedUser);
-  
-  const session = {
-    guest_user_id: insertedUser.id,
-    guest_first_name: insertedUser.first_name,
-    guest_stay_id: insertedUser.stay_id
-  };
-  
+
   try {
     saveGuestSession(session);
     setTableNumber(table_number);
     console.log('[createGuestUser] Session saved successfully:', session);
   } catch (storageError) {
     console.warn('[createGuestUser] Failed to save session to localStorage:', storageError);
-    // Don't throw here - the user was created successfully in the database
+    // Don't throw here - the guest was registered successfully server-side.
   }
-  
+
   return session;
 }
 

--- a/supabase/migrations/20260712000000_restrict_guests_anon_access.sql
+++ b/supabase/migrations/20260712000000_restrict_guests_anon_access.sql
@@ -1,0 +1,53 @@
+-- C3: Remove world-readable / world-insertable access to public.guests.
+--
+-- Live audit (2026-07-11) confirmed the anon role could SELECT every guest row
+-- (4,519 rows: first_name, stay_id, table_number) and INSERT arbitrary rows.
+-- The exposed (id, stay_id) tuples are exactly what /api/guest/order-history and
+-- the guest order-placement path treat as an authorization credential, so the
+-- open SELECT enabled unauthenticated enumeration of every family's order
+-- history, and the open INSERT enabled forging guests under any enumerated stay.
+--
+-- Guest registration now runs server-side via POST /api/guest/register using the
+-- service-role client. The browser no longer touches this table directly, so we
+-- drop the always-true anon/public policies and revoke the direct grants.
+-- RLS stays enabled (deny-by-default); service_role bypasses RLS and keeps all
+-- registration / ordering / order-history / admin workflows working unchanged.
+--
+-- NOTE: this is a security-only DDL change. It does not modify any guest data.
+
+-- 1. Drop the always-true SELECT / INSERT policies (current live names).
+DROP POLICY IF EXISTS "Guests can view records." ON public.guests;
+DROP POLICY IF EXISTS "Guests can create records." ON public.guests;
+
+-- Also drop legacy-named / drifted policies from earlier migrations if present,
+-- so the table is left with no anon-facing policy regardless of history.
+DROP POLICY IF EXISTS "Guests can view their own records." ON public.guests;
+DROP POLICY IF EXISTS "Guests can create their own records." ON public.guests;
+DROP POLICY IF EXISTS "Guests can update records." ON public.guests;
+DROP POLICY IF EXISTS "Guests can update their own records." ON public.guests;
+
+-- 2. Revoke direct table privileges from the browser-facing roles.
+--    anon currently holds SELECT + INSERT; authenticated holds the same and is
+--    unused (admin reads go through RPCs / profiles, order routes use service
+--    role), so both are safe to revoke.
+REVOKE SELECT, INSERT ON public.guests FROM anon;
+REVOKE SELECT, INSERT ON public.guests FROM authenticated;
+
+-- 3. Keep RLS enabled: with no anon-facing policy, all non service-role access
+--    is denied by default.
+ALTER TABLE public.guests ENABLE ROW LEVEL SECURITY;
+
+-- ---------------------------------------------------------------------------
+-- ROLLBACK (run manually to restore the previous, insecure posture):
+--
+--   GRANT SELECT, INSERT ON public.guests TO anon, authenticated;
+--
+--   CREATE POLICY "Guests can view records." ON public.guests
+--     FOR SELECT USING (true);
+--
+--   CREATE POLICY "Guests can create records." ON public.guests
+--     FOR INSERT WITH CHECK (true);
+--
+-- (Reverting also requires redeploying the client build that wrote to
+--  public.guests directly, or pointing createGuestUser back at the table.)
+-- ---------------------------------------------------------------------------


### PR DESCRIPTION
## C3 — `public.guests` world-readable / world-insertable

### Problem (verified live, 2026-07-11)
With the publishable anon key alone, anyone could:
- **SELECT all 4,519 guest rows** (`first_name`, `stay_id`, `table_number`) via `USING (true)`.
- **INSERT arbitrary guest rows** via `WITH CHECK (true)`.

The exposed `(id, stay_id)` tuples are exactly the credential that `/api/guest/order-history` and guest order placement trust, so:
- **Chain A:** dump `(id, stay_id)` → `POST /api/guest/order-history` for any pair → read **every family's full order history** (names, items, totals, special instructions, table, timestamps), unauthenticated.
- **Chain B:** anon `INSERT` a guest under any enumerated `stay_id` → place orders attributed/grouped to that stay (room-charge / history pollution).

`UPDATE`/`DELETE` were already blocked in production (no policy/grant) — confirmed 401 in testing.

**Severity: High.** Supabase's own advisor flags `rls_policy_always_true` on the INSERT policy.

### Fix
1. **`POST /api/guest/register`** (service-role): strict validation of `first_name` / `stay_id` / `table_number`, server-side walk-in `stay_id` generation, duplicate-registration idempotency, and a **per-stay guest cap** (`MAX_GUESTS_PER_STAY = 25`). Decision logic is isolated in `src/lib/guestRegistration.ts` (no Supabase import) for unit testing; the route is a thin service-role adapter.
2. **`createGuestUser`** now calls the route instead of `supabase.from('guests')`. localStorage keys, `GuestSession` shape, and register-page redirects are unchanged.
3. **Migration** `20260712000000_restrict_guests_anon_access.sql`: drops the always-true SELECT/INSERT policies, revokes `SELECT, INSERT` from `anon` and `authenticated`, keeps RLS enabled, leaves service-role workflows untouched. Includes rollback SQL.

### Behaviour preserved
Hotel QR registration, second family member (same `stay_id`, different name), walk-in, duplicate registration, guest order placement, family order history, and admin/service-role reads (which use RPCs / service role, not the anon grants).

### Not in this PR — required follow-up
**Signed guest-session tokens / one-time QR tokens.** Removing enumeration is necessary but not sufficient: `stay_id` is still a low-entropy, guessable identifier that acts as a bearer credential. It should be replaced with a signed, server-issued session token so a leaked/guessed `stay_id` cannot authorize order history or placement.

### Tests
- `src/lib/guestRegistration.test.ts` (13): hotel-new, second-family-member, walk-in (no pre-check), duplicate idempotency, per-stay cap (429), insert-race 23505 recovery, validation.
- `src/utils/guestSession.test.ts` (2): posts to `/api/guest/register`, persists unchanged localStorage keys / session shape; surfaces server error.
- Full Vitest: **33/33 passing.** `tsc --noEmit` clean for changed files (pre-existing admin-page errors unrelated). New files lint clean.

### Post-deploy verification (after migration is applied — not done here)
- anon `GET/POST /rest/v1/guests` → 401.
- Chain-A replay against a harvested tuple → fails.
- Registration + ordering + history smoke test in the running app.

### Rollout order (do NOT apply migration before the app deploy)
1. Merge + deploy the app (route + `createGuestUser`) first.
2. **Then** apply the migration. Applying it before the deploy would break registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)