### PR TITLE
security(db): reconcile live schema drift — reproduce PRE-C1/PRE-C2 baseline

### DIFF
--- a/supabase/migrations/20260707000000_reconcile_live_schema_baseline.sql
+++ b/supabase/migrations/20260707000000_reconcile_live_schema_baseline.sql
@@ -1,0 +1,142 @@
+-- Reconcile live schema drift: reproduce the PRE-C1 / PRE-C2 production security
+-- baseline in the active migration history.
+--
+-- WHY: several security-relevant objects exist in production but were created
+-- out-of-band (dashboard/manual) and are NOT reproduced by any active migration.
+-- Without them, a fresh database (preview branch / DR rebuild) does not match
+-- production, and the hardening PRs cannot be faithfully validated:
+--   * public.orders has RLS DISABLED and no policies on a fresh build
+--     (production has RLS enabled + 4 policies).
+--   * public.get_user_role(uuid) does not exist on a fresh build
+--     (referenced by the orders own/admin policies).
+--   * public.profiles.deleted column does not exist on a fresh build
+--     (PR #177 / C2 references it and would fail to apply without it).
+--
+-- SCOPE: this migration reproduces the *baseline* (pre-hardening) state ONLY.
+-- It intentionally recreates the permissive orders policies that PR #176 (C1)
+-- later tightens, so C1 retains meaningful, reviewable migration coverage.
+-- It does NOT include the C1 (orders lock-down) or C2 (profiles privilege guard)
+-- hardening changes.
+--
+-- ORDERING: timestamp 20260707000000 sorts BEFORE C1 (20260708000000),
+-- C2 (20260711000000) and C3 (20260712000000) so a fresh rebuild applies the
+-- baseline first, then the hardening.
+--
+-- SAFETY: idempotent and non-destructive. Safe on a fresh database and on the
+-- existing production database (every statement is a no-op where the object
+-- already matches live). No data is modified.
+--
+-- Values below were captured verbatim from production (project wcplwmvbhreevxvsdmog):
+--   * orders policy USING/WITH CHECK expressions
+--   * get_user_role: STABLE, SECURITY DEFINER, search_path=public,pg_temp,
+--     EXECUTE to authenticated+service_role only (no PUBLIC), missing row -> NULL
+--   * profiles.deleted: boolean, default false, nullable
+
+begin;
+
+-- ---------------------------------------------------------------------------
+-- 1) public.get_user_role(uuid)
+--    Required by the baseline orders own/admin policies below. Canonical,
+--    faithful definition (production's live copy additionally emits debug
+--    RAISE NOTICE lines, which are behaviourally irrelevant and omitted here).
+-- ---------------------------------------------------------------------------
+create or replace function public.get_user_role(user_id uuid)
+returns text
+language plpgsql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  user_role text;
+begin
+  -- Missing profile row leaves user_role NULL (SELECT ... INTO finds no row),
+  -- so the function returns NULL for unknown users.
+  select lower(coalesce(role, 'customer')) into user_role
+  from public.profiles
+  where id = user_id;
+  return user_role;
+end;
+$$;
+
+-- Lock execute down to match live ACL: no PUBLIC execute.
+revoke all on function public.get_user_role(uuid) from public;
+grant execute on function public.get_user_role(uuid) to authenticated, service_role;
+
+-- ---------------------------------------------------------------------------
+-- 2) public.profiles.deleted
+--    Present in production (boolean, default false, nullable) but not created
+--    by any active migration. C2 (PR #177) depends on it.
+-- ---------------------------------------------------------------------------
+alter table public.profiles
+  add column if not exists deleted boolean default false;
+
+-- ---------------------------------------------------------------------------
+-- 3) public.orders baseline security state (PRE-C1)
+--    Enable RLS, ensure the standard table grants exist, and (re)create the
+--    four permissive baseline policies exactly as they exist live.
+-- ---------------------------------------------------------------------------
+alter table public.orders enable row level security;
+
+-- Standard Supabase table grants (idempotent; matches live). C1 later revokes
+-- the write privileges from anon/authenticated.
+grant select, insert, update, delete, truncate, references, trigger
+  on public.orders to anon, authenticated, service_role;
+
+-- INSERT: guests (user_id null + guest_user_id present) or a user inserting
+-- their own row. Applies to PUBLIC (all roles), matching live.
+drop policy if exists "Allow users to create their own orders" on public.orders;
+create policy "Allow users to create their own orders" on public.orders
+  for insert
+  to public
+  with check (
+    (auth.uid() = user_id) or ((user_id is null) and (guest_user_id is not null))
+  );
+
+-- SELECT (anon): 15-minute guest order read-back window.
+drop policy if exists orders_select_guest_recent_readback on public.orders;
+create policy orders_select_guest_recent_readback on public.orders
+  for select
+  to anon
+  using (
+    (user_id is null) and (guest_user_id is not null)
+    and (created_at >= (now() - '00:15:00'::interval))
+  );
+
+-- SELECT (authenticated): own orders or admin.
+drop policy if exists orders_select_own_or_admin on public.orders;
+create policy orders_select_own_or_admin on public.orders
+  for select
+  to authenticated
+  using (
+    (user_id = auth.uid()) or (get_user_role(auth.uid()) = 'admin'::text)
+  );
+
+-- UPDATE (authenticated): own orders or admin.
+drop policy if exists orders_update_own_or_admin on public.orders;
+create policy orders_update_own_or_admin on public.orders
+  for update
+  to authenticated
+  using (
+    (user_id = auth.uid()) or (get_user_role(auth.uid()) = 'admin'::text)
+  )
+  with check (
+    (user_id = auth.uid()) or (get_user_role(auth.uid()) = 'admin'::text)
+  );
+
+commit;
+
+-- ---------------------------------------------------------------------------
+-- ROLLBACK NOTES (not executed)
+-- This migration is additive/reconciliatory. To reverse on a database where it
+-- introduced (rather than matched) objects:
+--   drop policy if exists orders_update_own_or_admin on public.orders;
+--   drop policy if exists orders_select_own_or_admin on public.orders;
+--   drop policy if exists orders_select_guest_recent_readback on public.orders;
+--   drop policy if exists "Allow users to create their own orders" on public.orders;
+--   -- (leave RLS enabled; disabling it would re-open orders)
+--   alter table public.profiles drop column if exists deleted;   -- data-bearing: verify unused first
+--   drop function if exists public.get_user_role(uuid);          -- only if no policy references it
+-- Do NOT run these on production: production already contains this baseline and
+-- these objects are in active use.
+-- ---------------------------------------------------------------------------

--- a/supabase/tests/reconcile_live_schema_baseline_test.sql
+++ b/supabase/tests/reconcile_live_schema_baseline_test.sql
@@ -1,0 +1,82 @@
+-- Catalog assertions proving the PRE-C1 / PRE-C2 baseline exists.
+-- Run against a database that has 20260707000000_reconcile_live_schema_baseline
+-- applied (fresh preview branch), or against production read-only (production
+-- already contains this baseline, so every assertion passes there too).
+--
+--   psql "$DATABASE_URL" -f supabase/tests/reconcile_live_schema_baseline_test.sql
+--
+-- All statements are read-only (catalog SELECTs + one STABLE function call).
+
+do $$
+declare
+  n int;
+  txt text;
+begin
+  -- 1) orders RLS enabled -----------------------------------------------------
+  select relrowsecurity::int into n from pg_class
+    where oid = 'public.orders'::regclass;
+  assert n = 1, 'orders RLS is not enabled';
+
+  -- 2) orders baseline policies exist, correct cmd + roles + expressions ------
+  -- 2a. Allow users to create their own orders (INSERT, public)
+  select count(*) into n from pg_policies
+    where schemaname='public' and tablename='orders'
+      and policyname='Allow users to create their own orders'
+      and cmd='INSERT' and roles = '{public}'
+      and with_check = '((auth.uid() = user_id) OR ((user_id IS NULL) AND (guest_user_id IS NOT NULL)))';
+  assert n = 1, 'orders INSERT baseline policy missing or altered';
+
+  -- 2b. orders_select_guest_recent_readback (SELECT, anon, 15-min window)
+  select count(*) into n from pg_policies
+    where schemaname='public' and tablename='orders'
+      and policyname='orders_select_guest_recent_readback'
+      and cmd='SELECT' and roles = '{anon}'
+      and qual = '((user_id IS NULL) AND (guest_user_id IS NOT NULL) AND (created_at >= (now() - ''00:15:00''::interval)))';
+  assert n = 1, 'orders anon read-back baseline policy missing or altered';
+
+  -- 2c. orders_select_own_or_admin (SELECT, authenticated)
+  select count(*) into n from pg_policies
+    where schemaname='public' and tablename='orders'
+      and policyname='orders_select_own_or_admin'
+      and cmd='SELECT' and roles = '{authenticated}'
+      and qual = '((user_id = auth.uid()) OR (get_user_role(auth.uid()) = ''admin''::text))';
+  assert n = 1, 'orders_select_own_or_admin baseline policy missing or altered';
+
+  -- 2d. orders_update_own_or_admin (UPDATE, authenticated, USING + WITH CHECK)
+  select count(*) into n from pg_policies
+    where schemaname='public' and tablename='orders'
+      and policyname='orders_update_own_or_admin'
+      and cmd='UPDATE' and roles = '{authenticated}'
+      and qual = '((user_id = auth.uid()) OR (get_user_role(auth.uid()) = ''admin''::text))'
+      and with_check = '((user_id = auth.uid()) OR (get_user_role(auth.uid()) = ''admin''::text))';
+  assert n = 1, 'orders_update_own_or_admin baseline policy missing or altered';
+
+  -- 3) get_user_role(uuid): properties ---------------------------------------
+  select count(*) into n from pg_proc p join pg_namespace ns on ns.oid=p.pronamespace
+    where ns.nspname='public' and p.proname='get_user_role'
+      and pg_get_function_identity_arguments(p.oid)='user_id uuid'
+      and p.provolatile='s'          -- STABLE
+      and p.prosecdef                 -- SECURITY DEFINER
+      and array_to_string(p.proconfig,'|') = 'search_path=public, pg_temp';
+  assert n = 1, 'get_user_role missing or not STABLE/SECURITY DEFINER/fixed search_path';
+
+  -- 3a. no PUBLIC execute
+  assert not has_function_privilege('public', 'public.get_user_role(uuid)', 'EXECUTE'),
+    'get_user_role must not be executable by PUBLIC';
+  assert has_function_privilege('authenticated', 'public.get_user_role(uuid)', 'EXECUTE'),
+    'get_user_role should be executable by authenticated';
+  assert has_function_privilege('service_role', 'public.get_user_role(uuid)', 'EXECUTE'),
+    'get_user_role should be executable by service_role';
+
+  -- 3b. missing profile returns NULL
+  select public.get_user_role('00000000-0000-0000-0000-000000000000'::uuid) into txt;
+  assert txt is null, 'get_user_role should return NULL for an unknown user';
+
+  -- 4) profiles.deleted: boolean, default false, nullable --------------------
+  select count(*) into n from information_schema.columns
+    where table_schema='public' and table_name='profiles' and column_name='deleted'
+      and data_type='boolean' and is_nullable='YES' and column_default='false';
+  assert n = 1, 'profiles.deleted missing or wrong type/default/nullability';
+
+  raise notice 'OK: all baseline reconciliation assertions passed';
+end $$;


### PR DESCRIPTION
## Purpose

Make the **active** Supabase migrations reproduce the production security baseline that PRs #176 (C1), #177 (C2), and #178 (C3) depend on. Today several security-relevant objects exist in production only **out-of-band** (created via dashboard/manual), so a fresh preview branch or DR rebuild does **not** match production — and the hardening PRs cannot be faithfully validated (and would be unsafe on a fresh rebuild).

This PR reproduces the **PRE-C1 / PRE-C2 baseline only**. It deliberately recreates the permissive orders policies that C1 later tightens, so C1/C2 keep meaningful migration coverage. It contains **none** of the C1/C2/C3 hardening.

## Objects reconciled (all captured verbatim from prod `wcplwmvbhreevxvsdmog`)

| Object | Drift before this PR | Reconciled to |
|---|---|---|
| `public.orders` RLS | disabled on fresh build | `ENABLE ROW LEVEL SECURITY` |
| `orders` grants (anon/authenticated/service_role) | default only | full live grant set (SELECT/INSERT/UPDATE/DELETE/TRUNCATE/REFERENCES/TRIGGER) |
| `Allow users to create their own orders` (INSERT, public) | absent | `WITH CHECK ((auth.uid()=user_id) OR (user_id IS NULL AND guest_user_id IS NOT NULL))` |
| `orders_select_guest_recent_readback` (SELECT, anon) | absent | 15-minute guest read-back window |
| `orders_select_own_or_admin` (SELECT, authenticated) | absent | own OR `get_user_role(auth.uid())='admin'` |
| `orders_update_own_or_admin` (UPDATE, authenticated) | absent | own OR admin (USING + WITH CHECK) |
| `public.get_user_role(uuid)` | absent on fresh build | STABLE, SECURITY DEFINER, `search_path=public,pg_temp`, EXECUTE to authenticated+service_role only (no PUBLIC), missing profile → NULL |
| `public.profiles.deleted` | absent on fresh build | `boolean DEFAULT false`, nullable |

Only `profiles.deleted` was missing among the columns C2 needs (`customer_type`, `archived` already come from active migrations; verified). No other profile columns required.

## Scope guard (deliberately excluded)
- **C1**: no `REVOKE … FROM anon/authenticated`, no `orders_insert_authenticated_self`, does not drop the anon read-back policy.
- **C2**: no `enforce_profiles_privileged_columns` trigger, no `REVOKE UPDATE (…)` column privileges, no privilege-guard policies.
- **C3**: no `guests` DDL at all (the only "guests" token is a comment word).

Automated grep guards for each of the above are green (see validation).

## Ordering
`20260707000000` sorts **after** the latest active migration (`20260418090000`) and **before** C1 (`20260708000000`), C2 (`20260711000000`), C3 (`20260712000000`). A fresh rebuild applies: existing → **baseline (this PR)** → C1 → C2 → C3, ending in the hardened state.

## Safety
Idempotent (`create or replace`, `add column if not exists`, `enable row level security`, `drop policy if exists`+`create`). Non-destructive — no data changes. Safe on a fresh DB (creates baseline) and on existing production (no-op where objects already match). Rollback notes included in the migration.

## Validation performed
- **Target == live (read-only, prod):** ran the full catalog-assertion block from `supabase/tests/reconcile_live_schema_baseline_test.sql` against production read-only — **all assertions pass**, proving the migration's intended end-state exactly matches the current production baseline (RLS on; 4 orders policies with verbatim expressions; `get_user_role` STABLE/SECURITY DEFINER/fixed search_path/no PUBLIC execute/missing→NULL; `profiles.deleted` boolean/false/nullable). No DDL run on prod; nothing modified.
- **Fresh-apply safety (by construction):** every column referenced by the baseline policies (`orders.user_id`, `guest_user_id`, `created_at`) and by `get_user_role` (`profiles.role`) is created by active migrations that precede `20260707000000`.
- **Diff scope:** exactly two new files — the migration and the test. No app/code changes.
- **Hardening-leak guards:** grep checks confirm no C1/C2/C3 constructs present.

## Tests
`supabase/tests/reconcile_live_schema_baseline_test.sql` — plpgsql `ASSERT` catalog checks for every reconciled object. Run against a preview branch after apply, or against any DB with the baseline:
```
psql "$DATABASE_URL" -f supabase/tests/reconcile_live_schema_baseline_test.sql
```

## Remaining drift (out of scope for faithful C1/C2/C3 validation — not reconciled here)
Production also carries other out-of-band `profiles` policies (`profiles_select_own_or_admin`, `profiles_insert_own_or_admin`, `profiles_delete_admin`, `Users can view their own profile`, `Allow admins to delete profiles`) and legacy policies. These are **not** required to validate C1/C2/C3 (C2 recreates its own insert/update policies; SELECT/DELETE behavior isn't under test) and were intentionally left out to keep scope minimal. Flagging for a future full profiles-policy reconciliation if you want the repo to fully own profiles RLS.

⚠️ Not applied to production. Not merged or deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
