### PR TITLE
security: restore admin order deletion

### DIFF
--- a/app/admin/orders/page.tsx
+++ b/app/admin/orders/page.tsx
@@ -11,6 +11,8 @@ import OrdersDashboardHeader from '@/components/admin/OrdersDashboardHeader';
 import StatusTabs from '@/components/admin/StatusTabs';
 import DailySalesSummary from '@/src/components/admin/DailySalesSummary';
 import { supabase } from '@/integrations/supabase/client';
+import { deleteAdminOrders } from '@/services/orderService';
+import { getRemainingSelectedOrderIds, removeDeletedOrders } from '@/lib/adminOrderDelete';
 import { toast } from 'sonner';
 
 const ALL_TAB = "all";
@@ -29,9 +31,9 @@ function OrdersDashboardContent() {
   } = useFetchOrdersOptimized();
 
   // Import order selection and actions hooks separately
-  const [selectedOrders, setSelectedOrders] = useState<string[]>([]);
+  const [selectedOrders, setSelectedOrders] = useState<number[]>([]);
   
-  const toggleSelectOrder = (orderId: string) => {
+  const toggleSelectOrder = (orderId: number) => {
     setSelectedOrders(prev => 
       prev.includes(orderId) 
         ? prev.filter(id => id !== orderId)
@@ -39,7 +41,7 @@ function OrdersDashboardContent() {
     );
   };
   
-  const selectAllOrders = (orderIds: string[]) => {
+  const selectAllOrders = (orderIds: number[]) => {
     setSelectedOrders(orderIds);
   };
   
@@ -47,7 +49,7 @@ function OrdersDashboardContent() {
     setSelectedOrders([]);
   };
   
-  const updateOrderStatus = async (orderId: string, newStatus: OrderStatus) => {
+  const updateOrderStatus = async (orderId: number, newStatus: OrderStatus) => {
     try {
       const { error } = await supabase
         .from('orders')
@@ -58,7 +60,7 @@ function OrdersDashboardContent() {
       // Update local state immediately for better UX
       setOrders(prevOrders => 
         prevOrders.map(order => 
-          order.id === parseInt(orderId) ? { ...order, order_status: newStatus } : order
+          order.id === orderId ? { ...order, order_status: newStatus } : order
         )
       );
       toast.success(`Order status updated to ${newStatus}`);
@@ -68,18 +70,18 @@ function OrdersDashboardContent() {
     }
   };
   
-  const updateMultipleOrderStatuses = async (orderIds: string[], newStatus: OrderStatus) => {
+  const updateMultipleOrderStatuses = async (orderIds: number[], newStatus: OrderStatus) => {
     try {
       const { error } = await supabase
         .from('orders')
         .update({ order_status: newStatus })
-        .in('id', orderIds.map(id => parseInt(id)));
+        .in('id', orderIds);
       if (error) throw error;
       
       // Update local state immediately for better UX
       setOrders(prevOrders => 
         prevOrders.map(order => 
-          orderIds.includes(order.id.toString()) ? { ...order, order_status: newStatus } : order
+          orderIds.includes(order.id) ? { ...order, order_status: newStatus } : order
         )
       );
       toast.success(`${orderIds.length} orders updated to ${newStatus}`);
@@ -91,21 +93,24 @@ function OrdersDashboardContent() {
   
   const deleteSelectedOrders = async () => {
     if (selectedOrders.length === 0) return;
-    
+
     try {
-      const { error } = await supabase
-        .from('orders')
-        .delete()
-        .in('id', selectedOrders.map(id => parseInt(id)));
-      if (error) throw error;
-      
-      // Update local state immediately for better UX
-      setOrders(prevOrders => 
-        prevOrders.filter(order => !selectedOrders.includes(order.id.toString()))
-      );
-      setSelectedOrders([]);
-      toast.success(`${selectedOrders.length} orders deleted`);
+      // Deletion is default-denied for the browser client (RLS); go through the
+      // admin server route which authorizes and deletes with the service role.
+      const deletedIds = await deleteAdminOrders(selectedOrders);
+      if (deletedIds.length === 0) {
+        throw new Error('No matching orders were deleted');
+      }
+      // Only drop rows the server confirmed as deleted (safe on partial failure).
+      setOrders(prevOrders => removeDeletedOrders(prevOrders, deletedIds));
+      setSelectedOrders(prevSelected => getRemainingSelectedOrderIds(prevSelected, deletedIds));
+      if (deletedIds.length < selectedOrders.length) {
+        toast.warning(`${deletedIds.length} of ${selectedOrders.length} selected orders deleted`);
+      } else {
+        toast.success(`${deletedIds.length} orders deleted`);
+      }
     } catch (error: unknown) {
+      // Leave rows visible on failure and surface the error.
       const message = error instanceof Error ? error.message : 'Unknown error';
       toast.error(`Failed to delete orders: ${message}`);
     }

--- a/app/api/admin/orders/delete/route.ts
+++ b/app/api/admin/orders/delete/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { createServiceRoleClient, verifyAdminRole } from '@/lib/supabase-server';
+import { handleAdminOrderDelete, parseOrderIds, type OrderDeleteStore } from '@/lib/adminOrderDelete';
+
+export const runtime = 'nodejs';
+
+export async function POST(request: NextRequest) {
+  // Authorize first so unauthenticated/non-admin callers never reach the DB.
+  const admin = await verifyAdminRole();
+
+  if (!admin.userId) {
+    return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+  }
+
+  if (!admin.isAdmin) {
+    return NextResponse.json({ error: 'Admin access required' }, { status: 403 });
+  }
+
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON payload' }, { status: 400 });
+  }
+
+  const parsed = parseOrderIds(payload);
+  if (!parsed.ok) {
+    return NextResponse.json({ error: parsed.error }, { status: parsed.status });
+  }
+
+  const serviceClient = createServiceRoleClient();
+  if (!serviceClient) {
+    return NextResponse.json({ error: 'Order service unavailable' }, { status: 503 });
+  }
+
+  const store: OrderDeleteStore = {
+    async deleteByIds(ids) {
+      const { data, error } = await serviceClient
+        .from('orders')
+        .delete()
+        .in('id', ids)
+        .select('id');
+      if (error) throw error;
+      return (data ?? []).map((row) => row.id as number);
+    },
+  };
+
+  const result = await handleAdminOrderDelete(
+    payload,
+    { isAdmin: admin.isAdmin, userId: admin.userId },
+    store,
+  );
+
+  return NextResponse.json(result.body, { status: result.status });
+}

--- a/src/hooks/useOrderActions.ts
+++ b/src/hooks/useOrderActions.ts
@@ -4,6 +4,8 @@ import { supabase } from '@/integrations/supabase/client';
 import { Order, OrderStatus } from '@/types/supabaseTypes';
 import { toast } from 'sonner';
 import { useQueryClient } from '@tanstack/react-query';
+import { deleteAdminOrders } from '@/services/orderService';
+import { getRemainingSelectedOrderIds, removeDeletedOrders } from '@/lib/adminOrderDelete';
 
 export const useOrderActions = (
   setOrders?: React.Dispatch<React.SetStateAction<Order[]>>
@@ -115,32 +117,35 @@ export const useOrderActions = (
   };
 
   const deleteSelectedOrders = async (
-    selectedOrders: string[], 
+    selectedOrders: Array<number | string>,
     setSelectedOrders: React.Dispatch<React.SetStateAction<number[]>>
   ) => {
     if (selectedOrders.length === 0) return;
-    
+
     try {
-      const { error } = await supabase
-        .from('orders')
-        .delete()
-        .in('id', selectedOrders);
-        
-      if (error) throw error;
-      
-      setOrders?.(prevOrders => 
-        prevOrders.filter(order => !selectedOrders.includes(order.id))
-      );
-      setSelectedOrders([]);
-      
-      // Invalidate specific queries for deleted orders
-      selectedOrders.forEach(orderId => {
-        queryClient.invalidateQueries({ queryKey: ['order', orderId] });
+      // Default-denied by RLS for the browser client; delete via the admin
+      // server route (service role) and only drop confirmed-deleted rows.
+      const deletedIds = await deleteAdminOrders(selectedOrders);
+      if (deletedIds.length === 0) {
+        throw new Error('No matching orders were deleted');
+      }
+
+      setOrders?.(prevOrders => removeDeletedOrders(prevOrders, deletedIds));
+      setSelectedOrders(prevSelected => getRemainingSelectedOrderIds(prevSelected, deletedIds));
+
+      // Invalidate specific queries for the orders that were actually deleted
+      deletedIds.forEach(orderId => {
+        queryClient.invalidateQueries({ queryKey: ['order', String(orderId)] });
       });
       queryClient.invalidateQueries({ queryKey: ['orders'] });
-      
-      toast.success(`Deleted ${selectedOrders.length} orders`);
+
+      if (deletedIds.length < selectedOrders.length) {
+        toast.warning(`Deleted ${deletedIds.length} of ${selectedOrders.length} selected orders`);
+      } else {
+        toast.success(`Deleted ${deletedIds.length} orders`);
+      }
     } catch (error: any) {
+      // Leave rows visible on failure and surface the error.
       console.error('Error deleting orders:', error);
       toast.error(`Failed to delete orders: ${error.message}`);
     }

--- a/src/lib/adminOrderDelete.test.ts
+++ b/src/lib/adminOrderDelete.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import {
+  getRemainingSelectedOrderIds,
+  handleAdminOrderDelete,
+  parseOrderIds,
+  removeDeletedOrders,
+} from './adminOrderDelete';
+import { deleteAdminOrders } from '@/services/orderService';
+
+describe('admin order deletion guard', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('allows an authenticated admin to delete orders', async () => {
+    const deleteByIds = vi.fn(async (ids: number[]) => ids);
+
+    const result = await handleAdminOrderDelete(
+      { orderIds: [101, '102', 101] },
+      { isAdmin: true, userId: 'admin-user' },
+      { deleteByIds },
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      status: 200,
+      body: { deletedIds: [101, 102], count: 2 },
+    });
+    expect(deleteByIds).toHaveBeenCalledWith([101, 102]);
+  });
+
+  it('denies non-admin callers before deletion', async () => {
+    const deleteByIds = vi.fn(async (ids: number[]) => ids);
+
+    const result = await handleAdminOrderDelete(
+      { orderIds: [101] },
+      { isAdmin: false, userId: 'normal-user' },
+      { deleteByIds },
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      status: 403,
+      body: { error: 'Admin access required' },
+    });
+    expect(deleteByIds).not.toHaveBeenCalled();
+  });
+
+  it('denies unauthenticated callers before deletion', async () => {
+    const deleteByIds = vi.fn(async (ids: number[]) => ids);
+
+    const result = await handleAdminOrderDelete(
+      { orderIds: [101] },
+      { isAdmin: false, userId: null },
+      { deleteByIds },
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      status: 401,
+      body: { error: 'Authentication required' },
+    });
+    expect(deleteByIds).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid or missing order ids', () => {
+    expect(parseOrderIds({})).toMatchObject({
+      ok: false,
+      status: 400,
+      error: 'orderIds must be a non-empty array',
+    });
+    expect(parseOrderIds({ orderIds: [] })).toMatchObject({
+      ok: false,
+      status: 400,
+      error: 'At least one order id is required',
+    });
+    expect(parseOrderIds({ orderIds: [0] })).toMatchObject({
+      ok: false,
+      status: 400,
+      error: 'Order ids must be positive integers',
+    });
+    expect(parseOrderIds({ orderIds: ['1.5'] })).toMatchObject({
+      ok: false,
+      status: 400,
+      error: 'Order ids must be positive integers',
+    });
+  });
+
+  it('does not expose internal deletion errors', async () => {
+    const result = await handleAdminOrderDelete(
+      { orderIds: [101] },
+      { isAdmin: true, userId: 'admin-user' },
+      {
+        deleteByIds: async () => {
+          throw new Error('permission denied for table orders');
+        },
+      },
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      status: 500,
+      body: { error: 'Failed to delete orders' },
+    });
+  });
+
+  it('keeps UI rows and selections when deletion fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        new Response(JSON.stringify({ error: 'Admin access required' }), {
+          status: 403,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      ),
+    );
+
+    const rows = [{ id: 101 }, { id: 102 }];
+    const selectedIds = [101, 102];
+
+    await expect(deleteAdminOrders(selectedIds)).rejects.toThrow('Admin access required');
+    expect(rows).toEqual([{ id: 101 }, { id: 102 }]);
+    expect(selectedIds).toEqual([101, 102]);
+  });
+
+  it('removes only server-confirmed deleted rows from UI state', () => {
+    const rows = [{ id: 101 }, { id: 102 }, { id: 103 }];
+
+    expect(removeDeletedOrders(rows, [101, '103'])).toEqual([{ id: 102 }]);
+    expect(getRemainingSelectedOrderIds([101, 102, 103], [101])).toEqual([102, 103]);
+  });
+
+  it('uses the admin API route from client code instead of service-role credentials', async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ deletedIds: [101], count: 1 }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(deleteAdminOrders([101])).resolves.toEqual([101]);
+    expect(fetchMock).toHaveBeenCalledWith('/api/admin/orders/delete', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ orderIds: [101] }),
+    });
+
+    const orderServiceSource = readFileSync(
+      resolve(process.cwd(), 'src/services/orderService.ts'),
+      'utf8',
+    );
+    expect(orderServiceSource).not.toContain('SUPABASE_SERVICE_ROLE_KEY');
+    expect(orderServiceSource).not.toContain('SUPABASE_SECRET_KEY');
+    expect(orderServiceSource).not.toContain('createServiceRoleClient');
+  });
+});

--- a/src/lib/adminOrderDelete.ts
+++ b/src/lib/adminOrderDelete.ts
@@ -1,0 +1,138 @@
+/**
+ * H5 — secure admin order deletion.
+ *
+ * `public.orders` has RLS enabled with NO authenticated DELETE policy, and C1
+ * revoked the DELETE grant from anon/authenticated, so a browser-side
+ * `supabase.from('orders').delete()` is default-denied. Deletion therefore runs
+ * server-side: POST /api/admin/orders/delete verifies the caller is an admin
+ * (verifyAdminRole) and deletes with the service-role client.
+ *
+ * This module holds the request-parsing, authorization, and result-shaping
+ * logic as pure functions so they can be unit tested without Next.js or
+ * Supabase. The route supplies the real admin check and a service-role-backed
+ * store; tests supply in-memory equivalents.
+ */
+
+/** Max order ids accepted in one bulk request (guards accidental huge deletes). */
+export const MAX_ORDER_IDS = 200;
+
+export interface AdminAuth {
+  isAdmin: boolean;
+  userId: string | null;
+}
+
+/** Data-access port. The route implements this over the service-role client. */
+export interface OrderDeleteStore {
+  /** Delete the given order ids; returns the ids actually deleted. */
+  deleteByIds(ids: number[]): Promise<number[]>;
+}
+
+export type AdminDeleteResult =
+  | { ok: true; status: 200; body: { deletedIds: number[]; count: number } }
+  | { ok: false; status: number; body: { error: string } };
+
+/**
+ * Validate the request body into a list of positive-integer order ids.
+ * Accepts `{ orderIds: [...] }` or a single `{ orderId: ... }`; numeric strings
+ * are coerced. Rejects empty / non-integer / non-positive / oversized inputs.
+ */
+export function parseOrderIds(
+  body: unknown,
+): { ok: true; ids: number[] } | { ok: false; status: number; error: string } {
+  if (typeof body !== 'object' || body === null) {
+    return { ok: false, status: 400, error: 'Invalid request payload' };
+  }
+  const record = body as Record<string, unknown>;
+  const raw =
+    record.orderIds !== undefined
+      ? record.orderIds
+      : record.orderId !== undefined
+        ? [record.orderId]
+        : undefined;
+
+  if (!Array.isArray(raw)) {
+    return { ok: false, status: 400, error: 'orderIds must be a non-empty array' };
+  }
+  if (raw.length === 0) {
+    return { ok: false, status: 400, error: 'At least one order id is required' };
+  }
+  if (raw.length > MAX_ORDER_IDS) {
+    return { ok: false, status: 400, error: `Too many order ids (max ${MAX_ORDER_IDS})` };
+  }
+
+  const ids: number[] = [];
+  const seen = new Set<number>();
+  for (const value of raw) {
+    // Coerce numeric strings, but reject anything that isn't a clean integer.
+    const n =
+      typeof value === 'number'
+        ? value
+        : typeof value === 'string' && value.trim() !== '' && /^\d+$/.test(value.trim())
+          ? Number(value.trim())
+          : NaN;
+    if (!Number.isInteger(n) || n <= 0) {
+      return { ok: false, status: 400, error: 'Order ids must be positive integers' };
+    }
+    if (!seen.has(n)) {
+      seen.add(n);
+      ids.push(n);
+    }
+  }
+  return { ok: true, ids };
+}
+
+/**
+ * Authorize + perform an admin order deletion. Denies unauthenticated (401) and
+ * non-admin (403) callers, validates ids (400), and never leaks internal DB
+ * errors (500 with a generic message).
+ */
+export async function handleAdminOrderDelete(
+  body: unknown,
+  auth: AdminAuth,
+  store: OrderDeleteStore,
+): Promise<AdminDeleteResult> {
+  if (!auth.userId) {
+    return { ok: false, status: 401, body: { error: 'Authentication required' } };
+  }
+  if (!auth.isAdmin) {
+    return { ok: false, status: 403, body: { error: 'Admin access required' } };
+  }
+
+  const parsed = parseOrderIds(body);
+  if (!parsed.ok) {
+    return { ok: false, status: parsed.status, body: { error: parsed.error } };
+  }
+
+  let deletedIds: number[];
+  try {
+    deletedIds = await store.deleteByIds(parsed.ids);
+  } catch {
+    // Do not surface the underlying Postgres/PostgREST error to the client.
+    return { ok: false, status: 500, body: { error: 'Failed to delete orders' } };
+  }
+
+  return { ok: true, status: 200, body: { deletedIds, count: deletedIds.length } };
+}
+
+/**
+ * Remove only the rows the server confirmed as deleted. Used by the UI so a
+ * failed or partial deletion never optimistically drops rows. Order id
+ * comparison is string-based to tolerate number/string id shapes.
+ */
+export function removeDeletedOrders<T extends { id: number | string }>(
+  orders: T[],
+  deletedIds: Array<number | string>,
+): T[] {
+  if (!deletedIds || deletedIds.length === 0) return orders;
+  const deleted = new Set(deletedIds.map((id) => String(id)));
+  return orders.filter((order) => !deleted.has(String(order.id)));
+}
+
+export function getRemainingSelectedOrderIds<T extends number | string>(
+  selectedIds: T[],
+  deletedIds: Array<number | string>,
+): T[] {
+  if (!deletedIds || deletedIds.length === 0) return selectedIds;
+  const deleted = new Set(deletedIds.map((id) => String(id)));
+  return selectedIds.filter((id) => !deleted.has(String(id)));
+}

--- a/src/services/deleteAdminOrders.test.ts
+++ b/src/services/deleteAdminOrders.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { deleteAdminOrders } from './orderService';
+
+describe('deleteAdminOrders (client)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('POSTs order ids to the admin route and returns confirmed deletedIds on success', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({ deletedIds: [1, 2], count: 2 }) });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const ids = await deleteAdminOrders([1, 2]);
+
+    expect(ids).toEqual([1, 2]);
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/admin/orders/delete',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({ orderIds: [1, 2] });
+  });
+
+  it('throws the server-provided error on failure (so the caller keeps rows visible)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: false, json: async () => ({ error: 'Admin access required' }) }),
+    );
+    await expect(deleteAdminOrders([1])).rejects.toThrow('Admin access required');
+  });
+
+  it('keeps service-role credentials out of H5 client code', () => {
+    const root = process.cwd();
+    const read = (p: string) => readFileSync(resolve(root, p), 'utf8');
+
+    const clientFiles = [
+      'src/services/orderService.ts',
+      'src/hooks/useOrderActions.ts',
+      'app/admin/orders/page.tsx',
+    ];
+    for (const file of clientFiles) {
+      const src = read(file);
+      expect(src, `${file} must not import the service-role client`).not.toMatch(/createServiceRoleClient/);
+      expect(src, `${file} must not reference service-role secrets`).not.toMatch(
+        /SUPABASE_SERVICE_ROLE|SUPABASE_SECRET/,
+      );
+    }
+
+    const route = read('app/api/admin/orders/delete/route.ts');
+    expect(route).toMatch(/createServiceRoleClient/);
+    expect(route).toMatch(/verifyAdminRole/);
+  });
+});

--- a/src/services/orderService.ts
+++ b/src/services/orderService.ts
@@ -221,6 +221,33 @@ export const createAdminCustomOrder = async (
   return payload.order;
 };
 
+/**
+ * Delete one or more orders as an admin via the server route (H5).
+ *
+ * Order deletion is default-denied by RLS for the browser client, so this goes
+ * through POST /api/admin/orders/delete, which verifies admin authorization and
+ * deletes with the service-role client. Returns the ids the server confirmed as
+ * deleted; throws with the server-provided message on failure so callers can
+ * keep rows visible and surface an error.
+ */
+export const deleteAdminOrders = async (
+  orderIds: Array<number | string>,
+): Promise<number[]> => {
+  const response = await fetch('/api/admin/orders/delete', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ orderIds }),
+  });
+
+  const payload = await response.json().catch(() => ({}));
+
+  if (!response.ok) {
+    throw new Error(payload?.error || 'Failed to delete orders');
+  }
+
+  return Array.isArray(payload?.deletedIds) ? payload.deletedIds : [];
+};
+
 export const getFilteredOrderHistory = (orders: Order[], userId?: string, hasGuestSession?: boolean) => {
   if (!userId) return [];
   


### PR DESCRIPTION
## Summary
- add `POST /api/admin/orders/delete` for admin-only order deletion
- verify admin authorization server-side with `verifyAdminRole()` before constructing the service-role delete path
- switch admin order deletion UI/helpers from browser-side Supabase delete to the API route
- remove rows from UI state only after server-confirmed `deletedIds`, preserving undeleted selections on partial success

## Root cause
The admin orders page attempted `supabase.from("orders").delete()` from the browser. After C1, `public.orders` has RLS enabled with no authenticated DELETE policy and anon/authenticated DELETE grants revoked, so the database correctly default-denies the browser operation while the UI could still remove rows locally.

## Security notes
- no Supabase migration or DELETE RLS policy added
- service-role client is only used inside the server route
- unauthenticated callers receive 401; non-admin callers receive 403
- invalid/missing IDs are rejected before deletion
- internal Supabase/Postgres errors are logged/hidden behind a generic response
- scan confirmed the only `orders.delete()` call is the new server route

## Tests
- `npx vitest run src/lib/adminOrderDelete.test.ts src/services/deleteAdminOrders.test.ts`
- `npx vitest run`
- `npx next build --webpack`
- `git diff --check`

## Notes
- `npm run build` with default Turbopack panics in this sibling worktree because `node_modules` is a symlink outside the project root; webpack build passes.
- `npm run lint` is currently broken because `next lint` is parsed as a project directory by the installed Next CLI.
- `npx tsc --noEmit --pretty false` still reports broad pre-existing repo type drift unrelated to H5.
