### PR TITLE
feat: bind QR guests to active stay identities

### DIFF
--- a/app/api/guest/register/route.ts
+++ b/app/api/guest/register/route.ts
@@ -2,6 +2,7 @@ import { NextResponse, type NextRequest } from 'next/server';
 import { createServiceRoleClient } from '@/lib/supabase-server';
 import { registerGuest } from '@/lib/guestRegistration';
 import { createSupabaseGuestStore } from '@/lib/guestRegistrationStore';
+import { resolveActiveStayForFirstName } from '@/lib/guestStayIdentity';
 
 export const runtime = 'nodejs';
 
@@ -20,7 +21,19 @@ export async function POST(request: NextRequest) {
 
   let result;
   try {
-    result = await registerGuest(payload, createSupabaseGuestStore(serviceClient));
+    let registrationPayload = payload;
+    if (payload && typeof payload === 'object') {
+      const body = payload as Record<string, unknown>;
+      const suppliedStayId = typeof body.stay_id === 'string' ? body.stay_id.trim().toLowerCase() : '';
+      const isWalkInRequest = !suppliedStayId || suppliedStayId === 'unknown' || suppliedStayId.includes('walkin');
+      if (isWalkInRequest && typeof body.first_name === 'string') {
+        const inferredStayId = await resolveActiveStayForFirstName(serviceClient, body.first_name);
+        if (inferredStayId) {
+          registrationPayload = { ...body, stay_id: inferredStayId };
+        }
+      }
+    }
+    result = await registerGuest(registrationPayload, createSupabaseGuestStore(serviceClient));
   } catch (error) {
     console.error('[api/guest/register] Unexpected failure:', error);
     return NextResponse.json({ error: 'Failed to register guest' }, { status: 500 });

--- a/src/lib/guestStayIdentity.test.ts
+++ b/src/lib/guestStayIdentity.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeGuestFirstName, resolveUniqueActiveStay } from './guestStayIdentity';
+
+describe('guest stay identity resolution', () => {
+  it('normalizes diacritics and punctuation', () => {
+    expect(normalizeGuestFirstName(' Élodie ')).toBe('elodie');
+  });
+
+  it('resolves one exact first-name match among active stays', () => {
+    expect(
+      resolveUniqueActiveStay(
+        'Lode',
+        [{ stay_id: 'BH_VANSTEEN', observed_first_name: 'Lode' }],
+        [{ stay_id: 'BH_VANSTEEN', check_in_date: '2026-08-01', check_out_date: '2026-08-10' }],
+        '2026-08-07',
+      ),
+    ).toBe('BH_VANSTEEN');
+  });
+
+  it('does not resolve a name shared by two active stays', () => {
+    expect(
+      resolveUniqueActiveStay(
+        'Alex',
+        [
+          { stay_id: 'STAY_A', observed_first_name: 'Alex' },
+          { stay_id: 'STAY_B', observed_first_name: 'Alex' },
+        ],
+        [
+          { stay_id: 'STAY_A', check_in_date: '2026-08-01', check_out_date: '2026-08-10' },
+          { stay_id: 'STAY_B', check_in_date: '2026-08-05', check_out_date: '2026-08-12' },
+        ],
+        '2026-08-07',
+      ),
+    ).toBeNull();
+  });
+
+  it('does not resolve an inactive or fuzzy-only candidate', () => {
+    expect(
+      resolveUniqueActiveStay(
+        'Jon',
+        [{ stay_id: 'OLD_STAY', observed_first_name: 'John' }],
+        [{ stay_id: 'OLD_STAY', check_in_date: '2026-07-01', check_out_date: '2026-07-05' }],
+        '2026-08-07',
+      ),
+    ).toBeNull();
+  });
+});

--- a/src/lib/guestStayIdentity.ts
+++ b/src/lib/guestStayIdentity.ts
@@ -1,0 +1,112 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export interface StayIdentityCandidate {
+  stay_id: string;
+  observed_first_name: string | null;
+}
+
+export interface ActiveStayRow {
+  stay_id: string;
+  check_in_date: string | null;
+  check_out_date: string | null;
+}
+
+const NAME_ALIASES: Record<string, string> = {
+  jon: 'jonathan',
+  jonny: 'jonathan',
+  sue: 'susan',
+  suzy: 'susan',
+  liz: 'elizabeth',
+  lizzy: 'elizabeth',
+  bill: 'william',
+  bob: 'robert',
+  rob: 'robert',
+  stephan: 'stefan',
+  muhammad: 'mohamed',
+};
+
+export function normalizeGuestFirstName(value: unknown): string {
+  return String(value ?? '')
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '');
+}
+
+function canonicalGuestFirstName(value: unknown): string {
+  const normalized = normalizeGuestFirstName(value);
+  return NAME_ALIASES[normalized] ?? normalized;
+}
+
+function isActiveStay(row: ActiveStayRow, today: string): boolean {
+  return Boolean(
+    row.check_in_date &&
+      row.check_out_date &&
+      row.check_in_date <= today &&
+      row.check_out_date >= today,
+  );
+}
+
+/**
+ * Resolve only a unique active stay. Fuzzy similarity is intentionally not
+ * used here: a first-name-only QR registration must fail closed on ambiguity.
+ */
+export function resolveUniqueActiveStay(
+  firstName: string,
+  identities: StayIdentityCandidate[],
+  activeStays: ActiveStayRow[],
+  today: string,
+): string | null {
+  const target = canonicalGuestFirstName(firstName);
+  if (!target) return null;
+
+  const activeStayIds = new Set(
+    activeStays
+      .filter((row) => isActiveStay(row, today))
+      .map((row) => row.stay_id),
+  );
+  const matchingStayIds = new Set(
+    identities
+      .filter(
+        (row) =>
+          activeStayIds.has(row.stay_id) &&
+          canonicalGuestFirstName(row.observed_first_name) === target,
+      )
+      .map((row) => row.stay_id),
+  );
+
+  return matchingStayIds.size === 1 ? [...matchingStayIds][0] : null;
+}
+
+/** Read-only lookup used by the server-side registration route. */
+export async function resolveActiveStayForFirstName(
+  client: SupabaseClient<any>,
+  firstName: string,
+  today = new Date().toISOString().slice(0, 10),
+): Promise<string | null> {
+  const identityResult = await client
+    .from('stay_guest_identities')
+    .select('stay_id, observed_first_name')
+    .not('observed_first_name', 'is', null)
+    .limit(500);
+  if (identityResult.error) throw identityResult.error;
+
+  const identities = (identityResult.data ?? []) as StayIdentityCandidate[];
+  const stayIds = [...new Set(identities.map((row) => row.stay_id).filter(Boolean))];
+  if (!stayIds.length) return null;
+
+  const activeResult = await client
+    .from('incoming_guests')
+    .select('stay_id, check_in_date, check_out_date')
+    .eq('row_type', 'booking')
+    .in('stay_id', stayIds)
+    .limit(500);
+  if (activeResult.error) throw activeResult.error;
+
+  return resolveUniqueActiveStay(
+    firstName,
+    identities,
+    (activeResult.data ?? []) as ActiveStayRow[],
+    today,
+  );
+}


### PR DESCRIPTION
## What changed

- Resolve an ordinary table-QR first name to a unique current in-house stay using `stay_guest_identities`.
- Feed an inferred `stay_id` into the existing server-side `registerGuest` and guest-session/family-bill path.
- Fail closed for ambiguous, fuzzy-only, historical, or unavailable identities.
- Preserve explicit `/register/{stay_id}` behavior and walk-in fallback.
- Add resolver tests.

## Validation

- Full Vitest suite: 70 tests passed.
- Focused identity/registration tests: 18 tests passed.
- Full TypeScript check remains blocked by pre-existing generated-schema and Deno diagnostics; no diagnostics mention the new resolver or register route.

## Production boundary

- No deployment or database migration was performed.
- No retroactive order or family-bill reassignment is performed.