### PR TITLE
feat: enrich provisional guest identity from restaurant name

### DIFF
--- a/src/lib/guestStayIdentity.test.ts
+++ b/src/lib/guestStayIdentity.test.ts
@@ -1,5 +1,48 @@
 import { describe, expect, it } from 'vitest';
-import { normalizeGuestFirstName, resolveUniqueActiveStay } from './guestStayIdentity';
+import {
+  normalizeGuestFirstName,
+  resolveActiveStayForFirstName,
+  resolveRestaurantIdentity,
+  resolveUniqueActiveStay,
+  type IncomingGuestIdentityCandidate,
+  type StayIdentityCandidate,
+} from './guestStayIdentity';
+
+const today = '2026-08-07';
+const activeStay = (stay_id: string) => ({
+  stay_id,
+  check_in_date: '2026-08-01',
+  check_out_date: '2026-08-14',
+});
+
+const booking = (
+  stay_id: string,
+  first_name: string,
+  overrides: Partial<IncomingGuestIdentityCandidate> = {},
+): IncomingGuestIdentityCandidate => ({
+  id: `${stay_id}-${first_name}`,
+  stay_id,
+  first_name,
+  phone_e164: null,
+  nationality_alpha3: null,
+  ...activeStay(stay_id),
+  ...overrides,
+});
+
+const provisionalIdentity = (
+  stay_id: string,
+  identity_id = 'identity-1',
+): StayIdentityCandidate => ({
+  identity_id,
+  stay_id,
+  phone_e164: '+32485085210',
+  whapi_lid: null,
+  observed_first_name: null,
+  observed_display_name: null,
+  linked_incoming_guest_id: null,
+  verified: false,
+  evidence: { group_action: 'rescan' },
+});
 
 describe('guest stay identity resolution', () => {
   it('normalizes diacritics and punctuation', () => {
@@ -43,5 +86,144 @@ describe('guest stay identity resolution', () => {
         '2026-08-07',
       ),
     ).toBeNull();
+  });
+
+  it('resolves a unique booking first name to one provisional identity', () => {
+    const result = resolveRestaurantIdentity(
+      'Laurence',
+      [provisionalIdentity('BH_VANSTEEN')],
+      [activeStay('BH_VANSTEEN')],
+      [booking('BH_VANSTEEN', 'Laurence', { nationality_alpha3: 'BEL' })],
+      today,
+    );
+
+    expect(result).toMatchObject({
+      stayId: 'BH_VANSTEEN',
+      identity: { identity_id: 'identity-1' },
+      reason: 'unique_booking_name',
+    });
+  });
+
+  it('does not choose a phone identity when two active stays share the first name', () => {
+    const result = resolveRestaurantIdentity(
+      'Laurence',
+      [provisionalIdentity('STAY_A', 'identity-a'), provisionalIdentity('STAY_B', 'identity-b')],
+      [activeStay('STAY_A'), activeStay('STAY_B')],
+      [booking('STAY_A', 'Laurence'), booking('STAY_B', 'Laurence')],
+      today,
+    );
+
+    expect(result).toEqual({ stayId: null, identity: null, reason: 'ambiguous' });
+  });
+
+  it('keeps stay billing possible but refuses phone attribution for two provisional identities', () => {
+    const result = resolveRestaurantIdentity(
+      'Laurence',
+      [provisionalIdentity('BH_VANSTEEN', 'identity-a'), provisionalIdentity('BH_VANSTEEN', 'identity-b')],
+      [activeStay('BH_VANSTEEN')],
+      [booking('BH_VANSTEEN', 'Laurence')],
+      today,
+    );
+
+    expect(result).toEqual({ stayId: 'BH_VANSTEEN', identity: null, reason: 'unique_booking_name' });
+  });
+
+  it('refuses phone attribution when the booking has duplicate first names', () => {
+    const result = resolveRestaurantIdentity(
+      'Laurence',
+      [provisionalIdentity('BH_VANSTEEN')],
+      [activeStay('BH_VANSTEEN')],
+      [booking('BH_VANSTEEN', 'Laurence'), booking('BH_VANSTEEN', 'Laurence', { id: 'duplicate' })],
+      today,
+    );
+
+    expect(result).toEqual({ stayId: 'BH_VANSTEEN', identity: null, reason: 'unique_booking_name' });
+  });
+
+  it('persists restaurant evidence and reconciles the provisional phone to Laurence', async () => {
+    const identity = provisionalIdentity('BH_VANSTEEN');
+    const bookings = [booking('BH_VANSTEEN', 'Laurence', { id: 'laurence-id', nationality_alpha3: 'BEL' })];
+    const updates: Record<string, unknown>[] = [];
+    const client = {
+      from(table: string) {
+        const data = table === 'incoming_guests' ? bookings : [identity];
+        return {
+          select() { return this; },
+          eq() { return this; },
+          in() { return this; },
+          limit: async () => ({ data, error: null }),
+          update(values: Record<string, unknown>) {
+            updates.push(values);
+            return { eq: async () => ({ error: null }) };
+          },
+        };
+      },
+    };
+
+    await expect(resolveActiveStayForFirstName(client as never, 'Laurence', today)).resolves.toBe('BH_VANSTEEN');
+    expect(updates).toHaveLength(1);
+    expect(updates[0]).toMatchObject({
+      observed_first_name: 'Laurence',
+      observed_display_name: 'Laurence',
+      linked_incoming_guest_id: 'laurence-id',
+      match_method: 'exact_first_name_and_phone_country',
+      match_confidence: 0.96,
+      verified: true,
+    });
+    expect(updates[0].evidence).toMatchObject({ group_action: 'rescan' });
+    expect(updates[0].evidence).toHaveProperty('first_name_observations');
+  });
+
+  it('does not mutate or attribute an unmatched first name', async () => {
+    const updates: Record<string, unknown>[] = [];
+    const client = {
+      from(table: string) {
+        const data = table === 'incoming_guests' ? [booking('BH_VANSTEEN', 'Lode')] : [provisionalIdentity('BH_VANSTEEN')];
+        return {
+          select() { return this; },
+          eq() { return this; },
+          in() { return this; },
+          limit: async () => ({ data, error: null }),
+          update(values: Record<string, unknown>) {
+            updates.push(values);
+            return { eq: async () => ({ error: null }) };
+          },
+        };
+      },
+    };
+
+    await expect(resolveActiveStayForFirstName(client as never, 'Unknown', today)).resolves.toBeNull();
+    expect(updates).toEqual([]);
+  });
+
+  it('does not overwrite a verified identity when a conflicting name is entered', async () => {
+    const verifiedIdentity: StayIdentityCandidate = {
+      ...provisionalIdentity('BH_VANSTEEN'),
+      observed_first_name: 'Lode',
+      observed_display_name: 'Lode',
+      linked_incoming_guest_id: 'lode-id',
+      verified: true,
+    };
+    const updates: Record<string, unknown>[] = [];
+    const client = {
+      from(table: string) {
+        const data = table === 'incoming_guests'
+          ? [booking('BH_VANSTEEN', 'Laurence', { nationality_alpha3: 'BEL' })]
+          : [verifiedIdentity];
+        return {
+          select() { return this; },
+          eq() { return this; },
+          in() { return this; },
+          limit: async () => ({ data, error: null }),
+          update(values: Record<string, unknown>) {
+            updates.push(values);
+            return { eq: async () => ({ error: null }) };
+          },
+        };
+      },
+    };
+
+    await expect(resolveActiveStayForFirstName(client as never, 'Laurence', today)).resolves.toBe('BH_VANSTEEN');
+    expect(updates).toEqual([]);
   });
 });

--- a/src/lib/guestStayIdentity.ts
+++ b/src/lib/guestStayIdentity.ts
@@ -1,14 +1,34 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 
 export interface StayIdentityCandidate {
+  identity_id?: string;
   stay_id: string;
+  phone_e164?: string | null;
+  whapi_lid?: string | null;
   observed_first_name: string | null;
+  observed_display_name?: string | null;
+  linked_incoming_guest_id?: string | null;
+  verified?: boolean;
+  evidence?: Record<string, unknown> | null;
 }
 
 export interface ActiveStayRow {
   stay_id: string;
   check_in_date: string | null;
   check_out_date: string | null;
+}
+
+export interface IncomingGuestIdentityCandidate extends ActiveStayRow {
+  id: string;
+  first_name: string;
+  phone_e164: string | null;
+  nationality_alpha3: string | null;
+}
+
+export interface RestaurantIdentityResolution {
+  stayId: string | null;
+  identity: StayIdentityCandidate | null;
+  reason: 'named_identity' | 'unique_booking_name' | 'ambiguous' | 'no_match';
 }
 
 const NAME_ALIASES: Record<string, string> = {
@@ -25,6 +45,26 @@ const NAME_ALIASES: Record<string, string> = {
   muhammad: 'mohamed',
 };
 
+const PHONE_COUNTRY_PREFIXES = [
+  '+353', '+351', '+972', '+971', '+66', '+32', '+49', '+33', '+31', '+39',
+  '+44', '+41', '+43', '+34', '+1', '+7', '+20', '+27', '+30', '+45', '+46',
+  '+47', '+48', '+52', '+55', '+61', '+64', '+65', '+81', '+82', '+86', '+91',
+];
+
+const NATIONALITY_PHONE_COUNTRY: Record<string, string> = {
+  BEL: '+32',
+  CHE: '+41',
+  DEU: '+49',
+  ESP: '+34',
+  FRA: '+33',
+  GBR: '+44',
+  IRL: '+353',
+  ITA: '+39',
+  NLD: '+31',
+  THA: '+66',
+  USA: '+1',
+};
+
 export function normalizeGuestFirstName(value: unknown): string {
   return String(value ?? '')
     .normalize('NFKD')
@@ -36,6 +76,27 @@ export function normalizeGuestFirstName(value: unknown): string {
 function canonicalGuestFirstName(value: unknown): string {
   const normalized = normalizeGuestFirstName(value);
   return NAME_ALIASES[normalized] ?? normalized;
+}
+
+function normalizePhone(value: unknown): string {
+  const digits = String(value ?? '').replace(/\D/g, '');
+  return digits.startsWith('00') ? digits.slice(2) : digits;
+}
+
+function phoneCountryCallingCode(value: unknown): string | null {
+  const normalized = String(value ?? '').trim().replace(/^00/, '+');
+  if (!normalized.startsWith('+')) return null;
+  return PHONE_COUNTRY_PREFIXES
+    .sort((left, right) => right.length - left.length)
+    .find((prefix) => normalized.startsWith(prefix)) ?? null;
+}
+
+function candidateCountry(candidate: IncomingGuestIdentityCandidate): string | null {
+  return (
+    phoneCountryCallingCode(candidate.phone_e164) ??
+    NATIONALITY_PHONE_COUNTRY[String(candidate.nationality_alpha3 ?? '').toUpperCase()] ??
+    null
+  );
 }
 
 function isActiveStay(row: ActiveStayRow, today: string): boolean {
@@ -78,35 +139,194 @@ export function resolveUniqueActiveStay(
   return matchingStayIds.size === 1 ? [...matchingStayIds][0] : null;
 }
 
-/** Read-only lookup used by the server-side registration route. */
+function matchIdentityToIncomingGuest(
+  identity: StayIdentityCandidate,
+  candidates: IncomingGuestIdentityCandidate[],
+): { guestId: string; method: string; confidence: number } | null {
+  const observedName = canonicalGuestFirstName(identity.observed_first_name);
+  const observedPhone = normalizePhone(identity.phone_e164);
+  const observedCountry = phoneCountryCallingCode(identity.phone_e164);
+  const scored = candidates.flatMap((candidate) => {
+    const exactPhone = Boolean(
+      observedPhone && normalizePhone(candidate.phone_e164) === observedPhone,
+    );
+    const exactName = Boolean(
+      observedName && observedName === canonicalGuestFirstName(candidate.first_name),
+    );
+    const countryMatch = Boolean(
+      observedCountry && candidateCountry(candidate) === observedCountry,
+    );
+    if (!exactPhone && !exactName) return [];
+    if (exactPhone) {
+      return [{ guestId: candidate.id, method: exactName ? 'exact_first_name_and_phone' : 'exact_phone', confidence: 1 }];
+    }
+    return [{
+      guestId: candidate.id,
+      method: countryMatch ? 'exact_first_name_and_phone_country' : 'exact_first_name_only',
+      confidence: countryMatch ? 0.96 : 0.82,
+    }];
+  });
+
+  if (!scored.length) return null;
+  const bestConfidence = Math.max(...scored.map((match) => match.confidence));
+  const best = scored.filter((match) => match.confidence === bestConfidence);
+  return best.length === 1 && bestConfidence >= 0.96 ? best[0] : null;
+}
+
+/** Resolve the stay and, only when safe, the single identity row to enrich. */
+export function resolveRestaurantIdentity(
+  firstName: string,
+  identities: StayIdentityCandidate[],
+  activeStays: ActiveStayRow[],
+  bookings: IncomingGuestIdentityCandidate[],
+  today: string,
+): RestaurantIdentityResolution {
+  const namedStayId = resolveUniqueActiveStay(firstName, identities, activeStays, today);
+  if (namedStayId) {
+    const matchingNamedIdentities = identities.filter(
+      (identity) =>
+        identity.stay_id === namedStayId &&
+        canonicalGuestFirstName(identity.observed_first_name) === canonicalGuestFirstName(firstName),
+    );
+    return {
+      stayId: namedStayId,
+      identity: matchingNamedIdentities.length === 1 ? matchingNamedIdentities[0] : null,
+      reason: 'named_identity',
+    };
+  }
+
+  const activeBookingStayIds = new Set(
+    bookings
+      .filter((booking) => isActiveStay(booking, today))
+      .filter((booking) => canonicalGuestFirstName(booking.first_name) === canonicalGuestFirstName(firstName))
+      .map((booking) => booking.stay_id),
+  );
+  if (activeBookingStayIds.size !== 1) {
+    return { stayId: null, identity: null, reason: activeBookingStayIds.size ? 'ambiguous' : 'no_match' };
+  }
+
+  const stayId = [...activeBookingStayIds][0];
+  const provisionalIdentities = identities.filter(
+    (identity) =>
+      identity.stay_id === stayId &&
+      !identity.observed_first_name &&
+      Boolean(identity.phone_e164 || identity.whapi_lid),
+  );
+  const matchingBookings = bookings.filter(
+    (booking) =>
+      booking.stay_id === stayId &&
+      isActiveStay(booking, today) &&
+      canonicalGuestFirstName(booking.first_name) === canonicalGuestFirstName(firstName),
+  );
+
+  return {
+    stayId,
+    identity: provisionalIdentities.length === 1 && matchingBookings.length === 1
+      ? provisionalIdentities[0]
+      : null,
+    reason: 'unique_booking_name',
+  };
+}
+
+function mergeRestaurantEvidence(
+  identity: StayIdentityCandidate,
+  firstName: string,
+): Record<string, unknown> {
+  const existing = identity.evidence && typeof identity.evidence === 'object'
+    ? identity.evidence
+    : {};
+  const observations = Array.isArray(existing.first_name_observations)
+    ? existing.first_name_observations.filter((entry) => entry && typeof entry === 'object')
+    : [];
+  const normalized = normalizeGuestFirstName(firstName);
+  const alreadyRecorded = observations.some(
+    (entry) => normalizeGuestFirstName((entry as Record<string, unknown>).first_name) === normalized &&
+      (entry as Record<string, unknown>).source === 'restaurant_qr_registration',
+  );
+  return {
+    ...existing,
+    first_name_observations: alreadyRecorded
+      ? observations
+      : [
+          ...observations,
+          { source: 'restaurant_qr_registration', first_name: firstName, observed_at: new Date().toISOString() },
+        ],
+  };
+}
+
+async function persistRestaurantFirstNameEvidence(
+  client: SupabaseClient,
+  identity: StayIdentityCandidate,
+  firstName: string,
+  bookings: IncomingGuestIdentityCandidate[],
+): Promise<void> {
+  if (!identity.identity_id) return;
+
+  const updates: Record<string, unknown> = {
+    evidence: mergeRestaurantEvidence(identity, firstName),
+    updated_at: new Date().toISOString(),
+  };
+  const observedFirstName = identity.observed_first_name || firstName;
+  if (!identity.observed_first_name && !identity.verified) {
+    updates.observed_first_name = firstName;
+    updates.observed_display_name = firstName;
+  }
+
+  const match = matchIdentityToIncomingGuest(
+    { ...identity, observed_first_name: observedFirstName },
+    bookings.filter((booking) => booking.stay_id === identity.stay_id),
+  );
+  if (match && (!identity.verified || !identity.linked_incoming_guest_id || identity.linked_incoming_guest_id === match.guestId)) {
+    updates.linked_incoming_guest_id = match.guestId;
+    updates.match_method = match.method;
+    updates.match_confidence = match.confidence;
+    updates.verified = true;
+  }
+
+  const result = await client
+    .from('stay_guest_identities')
+    .update(updates)
+    .eq('identity_id', identity.identity_id);
+  if (result.error) throw result.error;
+}
+
+/** Resolve a stay from a first-name registration and safely enrich one identity. */
 export async function resolveActiveStayForFirstName(
-  client: SupabaseClient<any>,
+  client: SupabaseClient,
   firstName: string,
   today = new Date().toISOString().slice(0, 10),
 ): Promise<string | null> {
+  const activeResult = await client
+    .from('incoming_guests')
+    .select('id, stay_id, first_name, phone_e164, nationality_alpha3, check_in_date, check_out_date')
+    .eq('row_type', 'booking')
+    .limit(1000);
+  if (activeResult.error) throw activeResult.error;
+
+  const bookings = (activeResult.data ?? []) as IncomingGuestIdentityCandidate[];
+  const activeStayIds = [...new Set(
+    bookings.filter((booking) => isActiveStay(booking, today)).map((booking) => booking.stay_id),
+  )];
+  if (!activeStayIds.length) return null;
+
   const identityResult = await client
     .from('stay_guest_identities')
-    .select('stay_id, observed_first_name')
-    .not('observed_first_name', 'is', null)
-    .limit(500);
+    .select('identity_id, stay_id, phone_e164, whapi_lid, observed_first_name, observed_display_name, linked_incoming_guest_id, verified, evidence')
+    .in('stay_id', activeStayIds)
+    .limit(1000);
   if (identityResult.error) throw identityResult.error;
 
   const identities = (identityResult.data ?? []) as StayIdentityCandidate[];
-  const stayIds = [...new Set(identities.map((row) => row.stay_id).filter(Boolean))];
-  if (!stayIds.length) return null;
-
-  const activeResult = await client
-    .from('incoming_guests')
-    .select('stay_id, check_in_date, check_out_date')
-    .eq('row_type', 'booking')
-    .in('stay_id', stayIds)
-    .limit(500);
-  if (activeResult.error) throw activeResult.error;
-
-  return resolveUniqueActiveStay(
+  const resolution = resolveRestaurantIdentity(
     firstName,
     identities,
-    (activeResult.data ?? []) as ActiveStayRow[],
+    activeStayIds.map((stay_id) => ({ stay_id, check_in_date: today, check_out_date: today })),
+    bookings,
     today,
   );
+  if (resolution.identity) {
+    await persistRestaurantFirstNameEvidence(client, resolution.identity, firstName, bookings);
+  }
+
+  return resolution.stayId;
 }


### PR DESCRIPTION
## What changed

- Reuses an existing provisional `stay_guest_identities` row when a restaurant first-name registration uniquely identifies an active stay.
- Persists restaurant first-name evidence without inserting a duplicate WhatsApp identity.
- Reconciles phone + first name + phone-country/passport-country only when the incoming guest match is unique and at least 0.96 confidence.
- Keeps stay-level restaurant billing available when passport linkage is unresolved or ambiguous.
- Preserves verified identity evidence and fails closed on conflicting or ambiguous cases.

## Production safety

- No WHAPI settings or channel changes.
- No WhatsApp messages.
- No real orders.
- No manual BH_VANSTEEN wife passport link.
- Explicit `/register/{stay_id}` behavior remains unchanged.

## Validation

- `vitest --run`: 77 passed.
- Targeted ESLint: passed.
- `git diff --check`: passed.
- Full TypeScript check remains blocked by existing generated-schema/Deno diagnostics; no diagnostics referenced the changed files.
- Next build was blocked before compilation by the isolated worktree's external `node_modules` symlink.