### PR TITLE
Restaurant WhatsApp order identity enrichment

### DIFF
--- a/src/types/supabaseTypes.ts
+++ b/src/types/supabaseTypes.ts
@@ -169,6 +169,9 @@ export type Database = {
           source_sender_phone_e164: string | null
           source_whapi_lid: string | null
           stay_id: string | null
+          status_message_channel_id: string | null
+          status_message_chat_id: string | null
+          status_message_id: string | null
           table_number: string | null
           total_amount: number
           updated_at: string
@@ -190,6 +193,9 @@ export type Database = {
           source_sender_phone_e164?: string | null
           source_whapi_lid?: string | null
           stay_id?: string | null
+          status_message_channel_id?: string | null
+          status_message_chat_id?: string | null
+          status_message_id?: string | null
           table_number?: string | null
           total_amount: number
           updated_at?: string
@@ -211,6 +217,9 @@ export type Database = {
           source_sender_phone_e164?: string | null
           source_whapi_lid?: string | null
           stay_id?: string | null
+          status_message_channel_id?: string | null
+          status_message_chat_id?: string | null
+          status_message_id?: string | null
           table_number?: string | null
           total_amount?: number
           updated_at?: string

--- a/src/types/supabaseTypes.ts
+++ b/src/types/supabaseTypes.ts
@@ -96,6 +96,12 @@ export type Database = {
           id: number
           order_items: Json | null
           order_status: Database["public"]["Enums"]["order_status"] | null
+          source_display_name: string | null
+          source_first_name: string | null
+          source_message_id: string | null
+          source_sender_id: string | null
+          source_sender_phone_e164: string | null
+          source_whapi_lid: string | null
           stay_id: string | null
           table_number: string | null
           total_amount: number
@@ -110,6 +116,12 @@ export type Database = {
           id?: number
           order_items?: Json | null
           order_status?: Database["public"]["Enums"]["order_status"] | null
+          source_display_name?: string | null
+          source_first_name?: string | null
+          source_message_id?: string | null
+          source_sender_id?: string | null
+          source_sender_phone_e164?: string | null
+          source_whapi_lid?: string | null
           stay_id?: string | null
           table_number?: string | null
           total_amount: number
@@ -124,6 +136,12 @@ export type Database = {
           id?: number
           order_items?: Json | null
           order_status?: Database["public"]["Enums"]["order_status"] | null
+          source_display_name?: string | null
+          source_first_name?: string | null
+          source_message_id?: string | null
+          source_sender_id?: string | null
+          source_sender_phone_e164?: string | null
+          source_whapi_lid?: string | null
           stay_id?: string | null
           table_number?: string | null
           total_amount?: number

--- a/src/types/supabaseTypes.ts
+++ b/src/types/supabaseTypes.ts
@@ -87,6 +87,71 @@ export type Database = {
         }
         Relationships: []
       }
+      restaurant_customer_identifiers: {
+        Row: {
+          created_at: string
+          customer_id: string
+          first_observed_at: string
+          identifier_id: string
+          identifier_type: string
+          identifier_value: string
+          last_observed_at: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          customer_id: string
+          first_observed_at?: string
+          identifier_id?: string
+          identifier_type: string
+          identifier_value: string
+          last_observed_at?: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          customer_id?: string
+          first_observed_at?: string
+          identifier_id?: string
+          identifier_type?: string
+          identifier_value?: string
+          last_observed_at?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "restaurant_customer_identifiers_customer_id_fkey"
+            columns: ["customer_id"]
+            isOneToOne: false
+            referencedRelation: "restaurant_customers"
+            referencedColumns: ["customer_id"]
+          },
+        ]
+      }
+      restaurant_customers: {
+        Row: {
+          created_at: string
+          customer_id: string
+          first_observed_at: string
+          last_observed_at: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          customer_id?: string
+          first_observed_at?: string
+          last_observed_at?: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          customer_id?: string
+          first_observed_at?: string
+          last_observed_at?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
       orders: {
         Row: {
           created_at: string
@@ -96,6 +161,7 @@ export type Database = {
           id: number
           order_items: Json | null
           order_status: Database["public"]["Enums"]["order_status"] | null
+          restaurant_customer_id: string | null
           source_display_name: string | null
           source_first_name: string | null
           source_message_id: string | null
@@ -116,6 +182,7 @@ export type Database = {
           id?: number
           order_items?: Json | null
           order_status?: Database["public"]["Enums"]["order_status"] | null
+          restaurant_customer_id?: string | null
           source_display_name?: string | null
           source_first_name?: string | null
           source_message_id?: string | null
@@ -136,6 +203,7 @@ export type Database = {
           id?: number
           order_items?: Json | null
           order_status?: Database["public"]["Enums"]["order_status"] | null
+          restaurant_customer_id?: string | null
           source_display_name?: string | null
           source_first_name?: string | null
           source_message_id?: string | null
@@ -149,6 +217,13 @@ export type Database = {
           user_id?: string | null
         }
         Relationships: [
+          {
+            foreignKeyName: "orders_restaurant_customer_id_fkey"
+            columns: ["restaurant_customer_id"]
+            isOneToOne: false
+            referencedRelation: "restaurant_customers"
+            referencedColumns: ["customer_id"]
+          },
           {
             foreignKeyName: "orders_user_id_fkey"
             columns: ["user_id"]
@@ -449,6 +524,16 @@ export type Database = {
           non_guest_count: number
           guest_amount: number
           non_guest_amount: number
+        }[]
+      }
+      resolve_restaurant_customer_identity: {
+        Args: {
+          p_phone_e164?: string | null
+          p_whapi_lid?: string | null
+        }
+        Returns: {
+          resolved_customer_id: string | null
+          resolution: string
         }[]
       }
       top_products_by_quantity: {

--- a/supabase/migrations/20260808122000_add_whatsapp_order_identity_columns.sql
+++ b/supabase/migrations/20260808122000_add_whatsapp_order_identity_columns.sql
@@ -1,0 +1,18 @@
+-- Preserve the inbound WhatsApp sender alongside every restaurant order.
+-- These fields are source evidence, not an assertion of passport identity.
+
+alter table public.orders
+  add column if not exists source_sender_id text,
+  add column if not exists source_sender_phone_e164 text,
+  add column if not exists source_message_id text,
+  add column if not exists source_first_name text,
+  add column if not exists source_display_name text,
+  add column if not exists source_whapi_lid text;
+
+create index if not exists idx_orders_source_sender_phone
+  on public.orders (source_sender_phone_e164)
+  where source_sender_phone_e164 is not null;
+
+create index if not exists idx_orders_source_message_id
+  on public.orders (source_message_id)
+  where source_message_id is not null;

--- a/supabase/migrations/20260812085137_restaurant_customer_identity.sql
+++ b/supabase/migrations/20260812085137_restaurant_customer_identity.sql
@@ -1,0 +1,180 @@
+-- Persistent restaurant identity is independent of a hotel stay. Orders keep
+-- their own stay_id snapshot; these rows only say which durable WhatsApp
+-- identity placed the order.
+
+create table if not exists public.restaurant_customers (
+  customer_id uuid primary key default gen_random_uuid(),
+  first_observed_at timestamptz not null default now(),
+  last_observed_at timestamptz not null default now(),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.restaurant_customer_identifiers (
+  identifier_id uuid primary key default gen_random_uuid(),
+  customer_id uuid not null references public.restaurant_customers(customer_id) on delete restrict,
+  identifier_type text not null
+    check (identifier_type in ('whatsapp_phone', 'whapi_lid')),
+  identifier_value text not null,
+  first_observed_at timestamptz not null default now(),
+  last_observed_at timestamptz not null default now(),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint restaurant_customer_identifier_value_nonempty
+    check (identifier_value = btrim(identifier_value) and length(identifier_value) > 0),
+  constraint restaurant_customer_identifier_phone_format
+    check (
+      identifier_type <> 'whatsapp_phone'
+      or identifier_value ~ '^\+[1-9][0-9]{6,14}$'
+    ),
+  constraint restaurant_customer_identifier_lid_format
+    check (
+      identifier_type <> 'whapi_lid'
+      or identifier_value ~ '^[^[:space:]]+@lid$'
+    ),
+  unique (identifier_type, identifier_value)
+);
+
+create index if not exists idx_restaurant_customer_identifiers_customer
+  on public.restaurant_customer_identifiers (customer_id);
+
+alter table public.orders
+  add column if not exists restaurant_customer_id uuid;
+
+do $$
+begin
+  if not exists (
+    select 1
+      from pg_constraint
+     where conname = 'orders_restaurant_customer_id_fkey'
+       and conrelid = 'public.orders'::regclass
+  ) then
+    alter table public.orders
+      add constraint orders_restaurant_customer_id_fkey
+      foreign key (restaurant_customer_id)
+      references public.restaurant_customers(customer_id)
+      on delete restrict;
+  end if;
+end
+$$;
+
+create index if not exists idx_orders_restaurant_customer_created
+  on public.orders (restaurant_customer_id, created_at desc)
+  where restaurant_customer_id is not null;
+
+-- Service-role order writers are the only callers in this slice. Keep both
+-- identity tables private-by-default if they are exposed through PostgREST.
+alter table public.restaurant_customers enable row level security;
+alter table public.restaurant_customer_identifiers enable row level security;
+
+revoke all on table public.restaurant_customers from public, anon, authenticated;
+revoke all on table public.restaurant_customer_identifiers from public, anon, authenticated;
+grant select, insert, update on table public.restaurant_customers to service_role;
+grant select, insert, update on table public.restaurant_customer_identifiers to service_role;
+
+-- Resolve/create atomically so concurrent first orders with the same exact key
+-- cannot manufacture two customers. A phone/LID pair already owned by two
+-- customers returns a conflict and is never merged implicitly.
+create or replace function public.resolve_restaurant_customer_identity(
+  p_phone_e164 text default null,
+  p_whapi_lid text default null
+)
+returns table(resolved_customer_id uuid, resolution text)
+language plpgsql
+security invoker
+set search_path = public, pg_temp
+as $$
+declare
+  v_phone text := nullif(btrim(p_phone_e164), '');
+  v_lid text := nullif(btrim(p_whapi_lid), '');
+  v_phone_customer uuid;
+  v_lid_customer uuid;
+  v_customer uuid;
+  v_created boolean := false;
+begin
+  if v_phone is null and v_lid is null then
+    return query select null::uuid, 'missing_identity'::text;
+    return;
+  end if;
+  if v_phone is not null and v_phone !~ '^\+[1-9][0-9]{6,14}$' then
+    return query select null::uuid, 'invalid_phone'::text;
+    return;
+  end if;
+  if v_lid is not null and v_lid !~ '^[^[:space:]]+@lid$' then
+    return query select null::uuid, 'invalid_lid'::text;
+    return;
+  end if;
+
+  -- Deterministic lock order avoids same-key races and lock inversions.
+  if v_phone is not null then
+    perform pg_advisory_xact_lock(hashtextextended('restaurant:phone:' || v_phone, 0));
+  end if;
+  if v_lid is not null then
+    perform pg_advisory_xact_lock(hashtextextended('restaurant:lid:' || v_lid, 0));
+  end if;
+
+  select customer_id into v_phone_customer
+    from public.restaurant_customer_identifiers
+   where identifier_type = 'whatsapp_phone'
+     and identifier_value = v_phone;
+  select customer_id into v_lid_customer
+    from public.restaurant_customer_identifiers
+   where identifier_type = 'whapi_lid'
+     and identifier_value = v_lid;
+
+  if v_phone_customer is not null
+     and v_lid_customer is not null
+     and v_phone_customer <> v_lid_customer then
+    return query select null::uuid, 'conflicting_identifiers'::text;
+    return;
+  end if;
+
+  v_customer := coalesce(v_phone_customer, v_lid_customer);
+  if v_customer is null then
+    insert into public.restaurant_customers default values
+    returning customer_id into v_customer;
+    v_created := true;
+  end if;
+
+  if v_phone is not null and v_phone_customer is null then
+    insert into public.restaurant_customer_identifiers (
+      customer_id, identifier_type, identifier_value
+    ) values (
+      v_customer, 'whatsapp_phone', v_phone
+    );
+  end if;
+  if v_lid is not null and v_lid_customer is null then
+    insert into public.restaurant_customer_identifiers (
+      customer_id, identifier_type, identifier_value
+    ) values (
+      v_customer, 'whapi_lid', v_lid
+    );
+  end if;
+
+  update public.restaurant_customer_identifiers
+     set last_observed_at = now(), updated_at = now()
+   where customer_id = v_customer
+     and (
+       (identifier_type = 'whatsapp_phone' and identifier_value = v_phone)
+       or (identifier_type = 'whapi_lid' and identifier_value = v_lid)
+     );
+  update public.restaurant_customers
+     set last_observed_at = now(), updated_at = now()
+   where customer_id = v_customer;
+
+  return query
+  select v_customer, case when v_created then 'created' else 'reused' end;
+end;
+$$;
+
+revoke execute on function public.resolve_restaurant_customer_identity(text, text)
+  from public, anon, authenticated;
+grant execute on function public.resolve_restaurant_customer_identity(text, text)
+  to service_role;
+
+comment on table public.restaurant_customers is
+  'Durable restaurant customer identity. Hotel guest versus walk-in remains order context.';
+comment on table public.restaurant_customer_identifiers is
+  'Exact WhatsApp phone/LID keys for one durable restaurant customer; ambiguous identities are not merged.';
+comment on column public.orders.restaurant_customer_id is
+  'Stable restaurant customer that placed this order; stay_id remains the immutable order-time billing context.';

--- a/supabase/migrations/20260812101607_restaurant_order_status_reactions.sql
+++ b/supabase/migrations/20260812101607_restaurant_order_status_reactions.sql
@@ -1,0 +1,52 @@
+-- Staff status reactions must resolve through an exact provider message
+-- reference. The reference is additive and leaves customer/StayID history
+-- untouched.
+
+alter table public.orders
+  add column if not exists status_message_id text,
+  add column if not exists status_message_chat_id text,
+  add column if not exists status_message_channel_id text;
+
+do $$
+begin
+  if not exists (
+    select 1
+      from pg_constraint
+     where conname = 'orders_status_message_reference_complete'
+       and conrelid = 'public.orders'::regclass
+  ) then
+    alter table public.orders
+      add constraint orders_status_message_reference_complete
+      check (
+        (
+          status_message_id is null
+          and status_message_chat_id is null
+          and status_message_channel_id is null
+        )
+        or
+        (
+          status_message_id is not null
+          and status_message_chat_id is not null
+          and status_message_channel_id is not null
+          and status_message_id = btrim(status_message_id)
+          and length(status_message_id) between 4 and 512
+          and status_message_chat_id = btrim(status_message_chat_id)
+          and length(status_message_chat_id) between 7 and 128
+          and status_message_channel_id = btrim(status_message_channel_id)
+          and length(status_message_channel_id) between 1 and 64
+        )
+      );
+  end if;
+end
+$$;
+
+create unique index if not exists idx_orders_status_message_provider_unique
+  on public.orders (status_message_channel_id, status_message_id)
+  where status_message_id is not null;
+
+comment on column public.orders.status_message_id is
+  'Exact WHAPI message whose authorized staff reactions may advance this order status.';
+comment on column public.orders.status_message_chat_id is
+  'Exact WhatsApp chat for the status-message reaction target.';
+comment on column public.orders.status_message_channel_id is
+  'Exact WHAPI channel for the status-message reaction target.';


### PR DESCRIPTION
## Purpose

Add the durable restaurant-customer schema and exact provider-message correlation required for authorized staff order-status reactions.

## Persistent customer identity

- Add `restaurant_customers` as the stable identity record.
- Add unique exact WhatsApp phone and WHAPI LID identifiers.
- Add nullable `orders.restaurant_customer_id` with an indexed restrictive foreign key.
- Add the atomic exact-key customer resolver with fail-closed phone/LID conflicts.
- Keep customer identity private to the service role with RLS and explicit privileges.

## Staff reaction order status

- Add nullable `orders.status_message_id`, `status_message_chat_id`, and `status_message_channel_id`.
- Require the message reference to be wholly absent or wholly populated.
- Enforce one order per WHAPI channel/provider message ID.
- Retain the existing `order_status` enum; it already contains `new`, `preparing`, `completed`, `paid`, and `cancelled`.
- No status history, identity, StayID, or order-content rewrite is introduced.

The chatbot/order-writer counterpart is coconutbeaches/python-whatsapp-chatbot#103.

## Safety

- Draft checkpoint only; do not merge yet.
- No production deployment was performed.
- No migration was applied.
- No production data was changed.
- The two repository changes must be coordinated before any future migration or release.

## Validation

- The status-message migration passed from scratch in disposable PostgreSQL 15.
- Checks covered the `new` default, all-or-none references, uniqueness, and preservation of customer/StayID fields during a status-only update.
- The earlier customer resolver migration passed in disposable PostgreSQL 17.
- The changed generated TypeScript type file compiles in isolation.
- Diff checks passed; full repository TypeScript checking remains blocked by unrelated pre-existing errors.

